### PR TITLE
Remove UIScene background color to keep transparency

### DIFF
--- a/phaser-vertical-slice/src/scenes/UIScene.js
+++ b/phaser-vertical-slice/src/scenes/UIScene.js
@@ -39,8 +39,6 @@ export default class UIScene extends Phaser.Scene {
   }
 
   create() {
-    this.cameras.main.setBackgroundColor(0x000000);
-
     this.gameScene = this.scene.get(this.gameSceneKey);
     if (!this.gameScene) {
       this.gameScene = this.scene.get("GameScene");


### PR DESCRIPTION
## Summary
- remove the explicit camera background color from UIScene so the overlay remains transparent over the game scene

## Testing
- python -m http.server 4173 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68cafe8e946c832bbba7bd03ede085c2