### PR TITLE
Harden UIScene syntax for browser compatibility

### DIFF
--- a/phaser-vertical-slice/src/entities/Player.js
+++ b/phaser-vertical-slice/src/entities/Player.js
@@ -49,6 +49,7 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     this.stats = new CombatStats({ maxHP: 150, maxMP: 60 });
     this.hitstunTimer = 0;
     this.knockback = { x: 0, y: 0 };
+    this.inputDisabled = false;
 
     this.initBody(x, y);
     this.registerCollisions();
@@ -180,7 +181,7 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
   }
 
   handleInput() {
-    if (!this.input) {
+    if (!this.input || this.inputDisabled) {
       return;
     }
 
@@ -227,6 +228,11 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
       return;
     }
 
+    if (this.inputDisabled) {
+      this.setVelocityX(0);
+      return;
+    }
+
     this.handleInput();
 
     let move = 0;
@@ -264,7 +270,7 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
   }
 
   tryDash() {
-    if (this.isDashing || this.dashCooldownTimer > 0 || this.hitstunTimer > 0) {
+    if (this.inputDisabled || this.isDashing || this.dashCooldownTimer > 0 || this.hitstunTimer > 0) {
       return;
     }
 
@@ -368,5 +374,13 @@ export default class Player extends Phaser.Physics.Matter.Sprite {
     }
 
     super.setFrame(frameKey, false, false);
+  }
+
+  setInputEnabled(enabled) {
+    this.inputDisabled = !enabled;
+    if (!enabled) {
+      this.jumpBufferMs = 0;
+      this.setVelocityX(0);
+    }
   }
 }

--- a/phaser-vertical-slice/src/main.js
+++ b/phaser-vertical-slice/src/main.js
@@ -2,6 +2,7 @@
 import BootScene from "./scenes/BootScene.js";
 import PreloadScene from "./scenes/PreloadScene.js";
 import GameScene from "./scenes/GameScene.js";
+import UIScene from "./scenes/UIScene.js";
 
 const GAME_WIDTH = 1280;
 const GAME_HEIGHT = 720;
@@ -43,7 +44,7 @@ const config = {
     min: 30,
     forceSetTimeOut: false
   },
-  scene: [BootScene, PreloadScene, GameScene]
+  scene: [BootScene, PreloadScene, GameScene, UIScene]
 };
 
 function bootGame() {

--- a/phaser-vertical-slice/src/scenes/GameScene.js
+++ b/phaser-vertical-slice/src/scenes/GameScene.js
@@ -1,6 +1,6 @@
-﻿import Phaser from "../phaser.js";
+import Phaser from "../phaser.js";
 import PerfMeter from "../systems/PerfMeter.js";
-import AssetLoader, { ASSET_KEYS } from "../systems/AssetLoader.js";
+import { ASSET_KEYS } from "../systems/AssetLoader.js";
 import InputManager, { INPUT_KEYS } from "../systems/InputManager.js";
 import Player from "../entities/Player.js";
 import Pool from "../systems/Pool.js";
@@ -10,6 +10,7 @@ import Spawner from "../systems/Spawner.js";
 
 const CAMERA_DEADZONE_X = 0.4;
 const CAMERA_DEADZONE_Y = 0.3;
+const UI_SYNC_INTERVAL = 120;
 
 export default class GameScene extends Phaser.Scene {
   constructor() {
@@ -21,11 +22,22 @@ export default class GameScene extends Phaser.Scene {
     this.parallaxConfig = [];
     this.inputManager = null;
     this.player = null;
-    this.debugHud = null;
     this.audio = null;
     this.projectilePool = null;
     this.projectiles = new Set();
     this.mobSpawner = null;
+
+    this.inventory = [];
+    this.quickSlots = [];
+    this.optionsState = {};
+    this.bindingsDirty = false;
+    this.inventoryDirty = false;
+    this.quickSlotsDirty = false;
+    this.optionsDirty = false;
+    this.uiSyncTimer = 0;
+    this.menuState = { inventoryOpen: false, optionsOpen: false };
+    this.menuOpen = false;
+    this.lastFrameTime = 0;
   }
 
   create() {
@@ -64,9 +76,13 @@ export default class GameScene extends Phaser.Scene {
     });
 
     this.setupCamera();
-    this.createHud();
+
+    this.initializeGameData();
+    this.initializeUIBridge();
 
     this.perfMeter = new PerfMeter(this);
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.shutdown, this);
   }
 
   createParallax() {
@@ -164,28 +180,354 @@ export default class GameScene extends Phaser.Scene {
     }
   }
 
-  createHud() {
-    const hudText = this.add.text(20, 20, "", {
-      fontFamily: "Rubik, 'Segoe UI', sans-serif",
-      fontSize: "18px",
-      color: "#ffffff"
-    });
-    hudText.setScrollFactor(0);
-    hudText.setDepth(1001);
-    this.debugHud = hudText;
+  initializeGameData() {
+    this.inventory = [
+      {
+        id: "skyroot_tonic",
+        name: "Skyroot Tonic",
+        type: "consumable",
+        quantity: 3,
+        description: "Restores 40 HP over a short duration."
+      },
+      {
+        id: "azure_focus",
+        name: "Azure Focus",
+        type: "consumable",
+        quantity: 2,
+        description: "Instantly revitalises 30 MP."
+      },
+      {
+        id: "ember_shard",
+        name: "Ember Shard",
+        type: "material",
+        quantity: 5,
+        description: "Warm crystalline shard used for crafting combustion cores."
+      },
+      {
+        id: "wingburst_scroll",
+        name: "Wingburst Scroll",
+        type: "skill",
+        quantity: 1,
+        description: "Unlocks a temporary mid-air burst dash when consumed."
+      }
+    ];
+
+    this.quickSlots = [
+      { index: 0, itemId: "skyroot_tonic" },
+      { index: 1, itemId: "azure_focus" },
+      { index: 2, itemId: null },
+      { index: 3, itemId: "wingburst_scroll" }
+    ];
+
+    this.optionsState = {
+      masterVolume: 0.8,
+      sfxVolume: 0.9,
+      bgmVolume: 0.7,
+      resolutionScale: 1,
+      graphicsQuality: "High"
+    };
+
+    this.inventoryDirty = true;
+    this.quickSlotsDirty = true;
+    this.optionsDirty = true;
+    this.bindingsDirty = true;
+
+    this.audio.applyMixSettings(this.optionsState);
+    this.updateResolutionScale();
+    this.applyGraphicsQuality(this.optionsState.graphicsQuality);
+  }
+
+  initializeUIBridge() {
+    this.events.on("ui-options-change", this.applyOptionsPatch, this);
+    this.events.on("ui-assign-quick-slot", this.handleQuickSlotAssignment, this);
+    this.events.on("ui-close-panel", this.handleUIClosePanel, this);
+    this.events.on("ui-rebind-action", this.handleRebindAction, this);
+    this.events.on("ui-reset-bindings", this.handleResetBindings, this);
+    this.events.once("ui-ready", this.handleUIReady, this);
+
+    if (this.scene.isActive && this.scene.isActive("UIScene")) {
+      this.scene.stop("UIScene");
+    }
+    this.scene.launch("UIScene", { gameSceneKey: this.scene.key });
+    this.scene.bringToTop("UIScene");
+  }
+
+  handleUIReady() {
+    this.syncUI(true);
   }
 
   update(time, delta) {
+    this.lastFrameTime = delta;
     this.updateParallax();
-    this.updateHud();
-    this.handleCombatInput();
+    this.handleUtilityInput();
+
+    if (!this.menuOpen) {
+      this.handleCombatInput();
+    }
+
     this.mobSpawner?.update(time, delta);
     this.updateProjectiles();
     this.handleMobInteractions();
+    this.updateUIHeartbeat(delta);
+  }
+
+  handleUtilityInput() {
+    if (!this.inputManager) {
+      return;
+    }
+
+    if (this.inputManager.wasJustPressed(INPUT_KEYS.INVENTORY)) {
+      const open = !this.menuState.inventoryOpen;
+      this.menuState.inventoryOpen = open;
+      if (open && this.menuState.optionsOpen) {
+        this.menuState.optionsOpen = false;
+        this.events.emit("ui-panel", { panel: "options", open: false });
+      }
+      this.events.emit("ui-panel", { panel: "inventory", open });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+
+    if (this.inputManager.wasJustPressed(INPUT_KEYS.OPTIONS)) {
+      const open = !this.menuState.optionsOpen;
+      this.menuState.optionsOpen = open;
+      if (open && this.menuState.inventoryOpen) {
+        this.menuState.inventoryOpen = false;
+        this.events.emit("ui-panel", { panel: "inventory", open: false });
+      }
+      this.events.emit("ui-panel", { panel: "options", open });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+  }
+
+  handleMenuStateChanged() {
+    const isOpen = this.menuState.inventoryOpen || this.menuState.optionsOpen;
+    if (isOpen === this.menuOpen) {
+      return;
+    }
+
+    this.menuOpen = isOpen;
+    if (this.player) {
+      this.player.setInputEnabled(!this.menuOpen);
+    }
+    if (this.menuOpen) {
+      this.inputManager?.resetAll?.();
+    }
+    this.events.emit("ui-menu-state", { open: this.menuOpen });
+  }
+
+  handleUIClosePanel({ panel }) {
+    if (panel === "inventory" && this.menuState.inventoryOpen) {
+      this.menuState.inventoryOpen = false;
+      this.events.emit("ui-panel", { panel: "inventory", open: false });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    } else if (panel === "options" && this.menuState.optionsOpen) {
+      this.menuState.optionsOpen = false;
+      this.events.emit("ui-panel", { panel: "options", open: false });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+  }
+
+  handleQuickSlotAssignment({ slotIndex, itemId }) {
+    if (typeof slotIndex !== "number" || slotIndex < 0 || slotIndex >= this.quickSlots.length) {
+      return;
+    }
+    if (!itemId) {
+      this.quickSlots[slotIndex] = { index: slotIndex, itemId: null };
+      this.quickSlotsDirty = true;
+      this.syncUI(true);
+      return;
+    }
+    const item = this.inventory.find((entry) => entry.id === itemId);
+    if (!item) {
+      return;
+    }
+    this.quickSlots[slotIndex] = { index: slotIndex, itemId };
+    this.quickSlotsDirty = true;
+    this.syncUI(true);
+  }
+
+  handleRebindAction({ action, keyCode }) {
+    if (!action || typeof keyCode !== "number" || !Number.isFinite(keyCode)) {
+      return;
+    }
+    if (this.inputManager?.rebindAction(action, keyCode)) {
+      this.bindingsDirty = true;
+      this.syncUI(true);
+    }
+  }
+
+  handleResetBindings() {
+    if (!this.inputManager) {
+      return;
+    }
+    this.inputManager.resetAllBindings();
+    this.bindingsDirty = true;
+    this.syncUI(true);
+  }
+
+  applyOptionsPatch(patch) {
+    if (!patch) {
+      return;
+    }
+
+    this.optionsState = { ...this.optionsState, ...patch };
+    this.optionsDirty = true;
+    this.audio?.applyMixSettings(this.optionsState);
+
+    if (patch.resolutionScale !== undefined) {
+      this.updateResolutionScale();
+    }
+    if (patch.graphicsQuality !== undefined) {
+      this.applyGraphicsQuality(this.optionsState.graphicsQuality);
+    }
+
+    this.syncUI(true);
+  }
+
+  updateResolutionScale() {
+    const zoom = Phaser.Math.Clamp(this.optionsState.resolutionScale ?? 1, 0.7, 1.2);
+    this.cameras.main.setZoom(zoom);
+  }
+
+  applyGraphicsQuality(quality) {
+    const engine = this.matter?.world?.engine;
+    if (!engine) {
+      return;
+    }
+    if (quality === "Performance") {
+      engine.positionIterations = 4;
+      engine.velocityIterations = 3;
+    } else {
+      engine.positionIterations = 6;
+      engine.velocityIterations = 4;
+    }
+  }
+
+  updateUIHeartbeat(delta) {
+    this.uiSyncTimer += delta;
+    if (this.uiSyncTimer < UI_SYNC_INTERVAL) {
+      return;
+    }
+    this.uiSyncTimer = 0;
+    this.syncUI();
+  }
+
+  syncUI(force = false) {
+    const payload = this.buildUIState(force);
+    this.events.emit("ui-state", payload);
+    if (force || this.inventoryDirty) {
+      this.inventoryDirty = false;
+    }
+    if (force || this.quickSlotsDirty) {
+      this.quickSlotsDirty = false;
+    }
+    if (force || this.optionsDirty) {
+      this.optionsDirty = false;
+    }
+    if (force || this.bindingsDirty) {
+      this.bindingsDirty = false;
+    }
+  }
+
+  buildUIState(force = false) {
+    const hud = this.player
+      ? {
+          hp: Math.round(this.player.stats.hp),
+          maxHp: this.player.stats.maxHP,
+          mp: Math.round(this.player.stats.mp),
+          maxMp: this.player.stats.maxMP,
+          dashCooldown: Math.max(0, Math.round(this.player.dashCooldownTimer || 0)),
+          dashReady: (this.player.dashCooldownTimer || 0) <= 0,
+          menuOpen: this.menuOpen
+        }
+      : null;
+
+    const performance = {
+      fps: this.game.loop.actualFps || 0,
+      frameTime: this.lastFrameTime,
+      objects: this.children.list.length,
+      mobs: this.mobSpawner ? this.mobSpawner.getActiveMobs().length : 0,
+      projectiles: this.projectiles.size
+    };
+
+    const payload = {
+      hud,
+      performance,
+      menu: {
+        open: this.menuOpen,
+        inventoryOpen: this.menuState.inventoryOpen,
+        optionsOpen: this.menuState.optionsOpen
+      },
+      map: this.collectMapState()
+    };
+
+    if (force || this.quickSlotsDirty) {
+      payload.quickSlots = this.collectQuickSlotState();
+    }
+    if (force || this.inventoryDirty) {
+      payload.inventory = this.collectInventoryState();
+    }
+    if (force || this.optionsDirty) {
+      payload.options = { ...this.optionsState };
+    }
+    if (force || this.bindingsDirty) {
+      payload.bindings = this.collectBindingState();
+    }
+
+    return payload;
+  }
+
+  collectQuickSlotState() {
+    return this.quickSlots.map((slot) => {
+      const item = slot.itemId ? this.inventory.find((entry) => entry.id === slot.itemId) : null;
+      return {
+        index: slot.index,
+        itemId: slot.itemId,
+        name: item?.name ?? null,
+        quantity: item?.quantity ?? 0
+      };
+    });
+  }
+
+  collectInventoryState() {
+    return this.inventory.map((item) => ({ ...item }));
+  }
+
+  collectBindingState() {
+    if (!this.inputManager?.getBindingSnapshot) {
+      return [];
+    }
+    return this.inputManager.getBindingSnapshot();
+  }
+
+  collectMapState() {
+    if (!this.map) {
+      return null;
+    }
+    const mobs = [];
+    if (this.mobSpawner) {
+      this.mobSpawner.getActiveMobs().forEach((mob) => {
+        if (mob.active) {
+          mobs.push({ x: mob.x, y: mob.y });
+        }
+      });
+    }
+    const view = this.cameras.main.worldView;
+    return {
+      width: this.map.widthInPixels,
+      height: this.map.heightInPixels,
+      player: this.player ? { x: this.player.x, y: this.player.y } : null,
+      camera: { x: view.x, y: view.y, width: view.width, height: view.height },
+      mobs
+    };
   }
 
   handleCombatInput() {
-    if (!this.inputManager || !this.player) {
+    if (!this.inputManager || !this.player || this.menuOpen) {
       return;
     }
 
@@ -301,55 +643,27 @@ export default class GameScene extends Phaser.Scene {
     });
   }
 
-  updateHud() {
-    if (!this.debugHud || !this.player || !this.player.body) {
-      return;
-    }
-    const velocity = this.player.body.velocity;
-    const speedX = Math.round(velocity.x * 60);
-    const speedY = Math.round(velocity.y * 60);
-    const posX = Math.round(this.player.x);
-    const posY = Math.round(this.player.y);
-    const mobs = this.mobSpawner ? this.mobSpawner.getActiveMobs().length : 0;
-    const hp = this.player.stats.hp;       // 현재 체력
-    const maxHp = this.player.stats.maxHP; // 최대 체력
+  spawnDamageNumber(x, y, value, color) {
+    const tint = color ?? "#ff5e5e";
+    const text = this.add.text(x, y, String(value), {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "18px",
+      color: tint
+    });
+    text.setDepth(80);
+    text.setOrigin(0.5, 1);
 
-    this.debugHud.setText([
-     "Player",
-     `HP ${hp} / ${maxHp}`,
-      `X ${Math.round(this.player.body.velocity.x * 60)} px/s`,
-     `Y ${Math.round(this.player.body.velocity.y * 60)} px/s`,
-     `Pos ${Math.round(this.player.x)}, ${Math.round(this.player.y)}`,
-     `Ground ${this.player.isOnGround}`,
-     `Dash ${this.player.isDashing}`,
-     `Mobs ${this.mobSpawner ? this.mobSpawner.activeMobs.size : 0}`
-    ]);
-  }
-  spawnDamageNumber(x, y, value, color) 
-  {
-  if (color === undefined || color === null) color = "#ff5e5e";
-
-  const text = this.add.text(x, y, String(value), {
-    fontFamily: "Rubik, 'Segoe UI', sans-serif",
-    fontSize: "18px",
-    color
-  });
-  text.setDepth(80);
-  text.setOrigin(0.5, 1);
-
-  this.tweens.add({
-    targets: text,
-    y: y - 32,
-    alpha: 0,
-    duration: 400,
-    ease: "Cubic.Out",
-    onComplete: () => text.destroy()
-  });
+    this.tweens.add({
+      targets: text,
+      y: y - 32,
+      alpha: 0,
+      duration: 400,
+      ease: "Cubic.Out",
+      onComplete: () => text.destroy()
+    });
   }
 
-
-  spawnLoot(x, y) 
-  {
+  spawnLoot(x, y) {
     const loot = this.add.rectangle(x, y, 12, 12, 0xffd166);
     loot.setDepth(70);
     this.tweens.add({
@@ -369,5 +683,15 @@ export default class GameScene extends Phaser.Scene {
     this.layers = {};
     this.parallaxLayers = [];
     this.inputManager = null;
+    this.projectiles.clear();
+    if (this.scene.isActive && this.scene.isActive("UIScene")) {
+      this.scene.stop("UIScene");
+    }
+    this.events.off("ui-options-change", this.applyOptionsPatch, this);
+    this.events.off("ui-assign-quick-slot", this.handleQuickSlotAssignment, this);
+    this.events.off("ui-close-panel", this.handleUIClosePanel, this);
+    this.events.off("ui-rebind-action", this.handleRebindAction, this);
+    this.events.off("ui-reset-bindings", this.handleResetBindings, this);
+    this.events.off("ui-ready", this.handleUIReady, this);
   }
 }

--- a/phaser-vertical-slice/src/scenes/UIScene.js
+++ b/phaser-vertical-slice/src/scenes/UIScene.js
@@ -1,0 +1,901 @@
+import Phaser from "../phaser.js";
+import { INPUT_KEYS } from "../systems/InputManager.js";
+
+const HUD_DEPTH = 2000;
+const QUICK_SLOT_COUNT = 4;
+const MINI_MAP_SIZE = { width: 176, height: 112 };
+
+export default class UIScene extends Phaser.Scene {
+  constructor() {
+    super({ key: "UIScene" });
+    this.gameSceneKey = "GameScene";
+    this.gameScene = null;
+    this.hud = null;
+    this.hpBarWidth = 220;
+    this.mpBarWidth = 220;
+    this.performanceText = null;
+    this.quickSlotContainer = null;
+    this.quickSlotVisuals = [];
+    this.miniMapContainer = null;
+    this.miniMapGraphics = null;
+    this.inventoryContainer = null;
+    this.inventoryListText = null;
+    this.inventoryDetailText = null;
+    this.inventoryHintText = null;
+    this.inventoryData = [];
+    this.inventoryVisible = false;
+    this.inventorySelectionIndex = 0;
+    this.quickSlotData = [];
+    this.optionsContainer = null;
+    this.optionsListText = null;
+    this.optionsHintText = null;
+    this.optionsState = {};
+    this.optionsConfig = this.createOptionsConfig();
+    this.optionsVisible = false;
+    this.optionsSelectionIndex = 0;
+    this.navKeys = null;
+    this.bindingState = [];
+    this.bindingLookup = new Map();
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    this.optionsHintBase = "";
+  }
+
+  init(data) {
+    const providedKey = data && typeof data.gameSceneKey === "string" ? data.gameSceneKey : null;
+    this.gameSceneKey = providedKey || "GameScene";
+  }
+
+  create() {
+    this.gameScene = this.scene.get(this.gameSceneKey);
+    if (!this.gameScene) {
+      this.gameScene = this.scene.get("GameScene");
+    }
+
+    this.createHud();
+    this.createPerformanceReadout();
+    this.createQuickSlots();
+    this.createMiniMap();
+    this.createInventoryPanel();
+    this.createOptionsPanel();
+    this.installInputHandlers();
+
+    this.scene.bringToTop();
+    this.bindGameSceneEvents();
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.shutdown, this);
+
+    this.emitGameEvent("ui-ready");
+  }
+
+  bindGameSceneEvents() {
+    if (!this.gameScene || !this.gameScene.events) {
+      return;
+    }
+    this.gameScene.events.on("ui-state", this.handleStateUpdate, this);
+    this.gameScene.events.on("ui-panel", this.handlePanelToggle, this);
+    this.gameScene.events.on("ui-menu-state", this.handleMenuState, this);
+  }
+
+  emitGameEvent(eventName, payload) {
+    if (this.gameScene && this.gameScene.events) {
+      this.gameScene.events.emit(eventName, payload);
+    }
+  }
+
+  createHud() {
+    const container = this.add.container(24, 24).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 260, 96, 0x121625, 0.82)
+      .setOrigin(0, 0)
+      .setStrokeStyle(2, 0x2d314a, 0.85);
+    container.add(bg);
+
+    const hpLabel = this.add.text(16, 12, "HP", this.getLabelStyle());
+    container.add(hpLabel);
+    const hpBg = this.add
+      .rectangle(16, 36, this.hpBarWidth, 18, 0x1b2133, 0.92)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(1, 0xff849d, 0.8);
+    container.add(hpBg);
+    const hpFill = this.add.rectangle(16, 36, this.hpBarWidth, 14, 0xff5d6c).setOrigin(0, 0.5);
+    container.add(hpFill);
+    const hpText = this.add.text(16 + this.hpBarWidth + 12, 36, "0 / 0", this.getValueStyle()).setOrigin(0, 0.5);
+    container.add(hpText);
+
+    const mpLabel = this.add.text(16, 60, "MP", this.getLabelStyle());
+    container.add(mpLabel);
+    const mpBg = this.add
+      .rectangle(16, 82, this.mpBarWidth, 18, 0x171d2c, 0.92)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(1, 0x6bb0ff, 0.8);
+    container.add(mpBg);
+    const mpFill = this.add.rectangle(16, 82, this.mpBarWidth, 14, 0x5aa6ff).setOrigin(0, 0.5);
+    container.add(mpFill);
+    const mpText = this.add.text(16 + this.mpBarWidth + 12, 82, "0 / 0", this.getValueStyle()).setOrigin(0, 0.5);
+    container.add(mpText);
+
+    const dashText = this.add.text(16, 108, "Dash Ready", this.getHintStyle());
+    dashText.setAlpha(0.9);
+    container.add(dashText);
+
+    this.hud = {
+      container,
+      hpFill,
+      hpText,
+      mpFill,
+      mpText,
+      dashText
+    };
+  }
+
+  createPerformanceReadout() {
+    this.performanceText = this.add
+      .text(24, this.scale.height - 140, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "16px",
+        color: "#d3d7ff"
+      })
+      .setDepth(HUD_DEPTH)
+      .setScrollFactor(0);
+  }
+
+  createQuickSlots() {
+    const container = this.add.container(this.scale.width * 0.5, this.scale.height - 72).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 320, 68, 0x121625, 0.78)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x313855, 0.85);
+    container.add(bg);
+
+    const spacing = 72;
+    const offset = -((QUICK_SLOT_COUNT - 1) * spacing) / 2;
+    for (let i = 0; i < QUICK_SLOT_COUNT; i += 1) {
+      const slotX = offset + i * spacing;
+      const frame = this.add
+        .rectangle(slotX, 0, 52, 52, 0x1b2235, 0.9)
+        .setOrigin(0.5)
+        .setStrokeStyle(1, 0x4d5a7d, 0.9);
+      const label = this.add
+        .text(slotX, -8, "--", {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "16px",
+          color: "#f4f5ff"
+        })
+        .setOrigin(0.5);
+      const quantity = this.add
+        .text(slotX, 14, "", {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "14px",
+          color: "#9ba6d1"
+        })
+        .setOrigin(0.5);
+      const hotkey = this.add
+        .text(slotX, 24, `${i + 1}`, {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "12px",
+          color: "#94a0c8"
+        })
+        .setOrigin(0.5);
+
+      container.add(frame);
+      container.add(label);
+      container.add(quantity);
+      container.add(hotkey);
+
+      this.quickSlotVisuals.push({ frame, label, quantity, hotkey });
+    }
+
+    this.quickSlotContainer = container;
+  }
+
+  createMiniMap() {
+    const container = this.add.container(this.scale.width - 220, 20).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 200, 156, 0x111523, 0.86)
+      .setOrigin(0, 0)
+      .setStrokeStyle(2, 0x2d3955, 0.85);
+    const title = this.add.text(12, 10, "Mini-Map", this.getLabelStyle());
+    const mapFrame = this.add
+      .rectangle(12, 34, MINI_MAP_SIZE.width, MINI_MAP_SIZE.height, 0x0c101c, 0.92)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, 0x36446b, 0.8);
+    const graphics = this.add.graphics().setPosition(12, 34).setDepth(HUD_DEPTH + 1).setScrollFactor(0);
+
+    container.add([bg, title, mapFrame, graphics]);
+
+    this.miniMapContainer = container;
+    this.miniMapGraphics = graphics;
+  }
+
+  createInventoryPanel() {
+    const container = this.add
+      .container(this.scale.width * 0.5, this.scale.height * 0.5)
+      .setDepth(HUD_DEPTH + 10)
+      .setScrollFactor(0)
+      .setVisible(false);
+
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.55).setOrigin(0.5).setInteractive();
+    const panel = this.add
+      .rectangle(0, 0, 520, 360, 0x111522, 0.95)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x3a476a, 0.85);
+    const title = this.add.text(-220, -150, "Inventory", this.getTitleStyle());
+    const list = this.add
+      .text(-220, -110, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "18px",
+        color: "#f2f4ff",
+        lineSpacing: 6
+      })
+      .setOrigin(0, 0);
+    const detail = this.add
+      .text(-220, 40, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "16px",
+        color: "#d0d7ff",
+        wordWrap: { width: 480 }
+      })
+      .setOrigin(0, 0);
+    const hint = this.add
+      .text(
+        -220,
+        140,
+        "\u2191\u2193 \uc120\ud0dd \u2022 1~4 \ud035\uc2ac\ub86f \uc9c0\uc815 \u2022 ESC \ub2eb\uae30",
+        this.getHintStyle()
+      )
+      .setOrigin(0, 0);
+
+    overlay.on("pointerdown", () => {
+      this.emitGameEvent("ui-close-panel", { panel: "inventory" });
+    });
+
+    container.add([overlay, panel, title, list, detail, hint]);
+
+    this.inventoryContainer = container;
+    this.inventoryListText = list;
+    this.inventoryDetailText = detail;
+    this.inventoryHintText = hint;
+  }
+
+  createOptionsPanel() {
+    const container = this.add
+      .container(this.scale.width * 0.5, this.scale.height * 0.5)
+      .setDepth(HUD_DEPTH + 12)
+      .setScrollFactor(0)
+      .setVisible(false);
+
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.55).setOrigin(0.5).setInteractive();
+    const panel = this.add
+      .rectangle(0, 0, 460, 320, 0x111522, 0.95)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x2f4163, 0.85);
+    const title = this.add.text(-200, -130, "Options", this.getTitleStyle());
+    const list = this.add
+      .text(-200, -90, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "18px",
+        color: "#f2f4ff",
+        lineSpacing: 6
+      })
+      .setOrigin(0, 0);
+    const baseHint =
+      "\u2191\u2193 \ud56d\ubaa9 \uc774\ub3d9 \u2022 \u2190\u2192 \uac12 \uc870\uc815 \u2022 Enter \ud0a4 \uc7ac\uc124\uc815 \u2022 ESC \ub2eb\uae30";
+    const hint = this.add.text(-200, 120, baseHint, this.getHintStyle()).setOrigin(0, 0);
+
+    overlay.on("pointerdown", () => {
+      this.emitGameEvent("ui-close-panel", { panel: "options" });
+    });
+
+    container.add([overlay, panel, title, list, hint]);
+
+    this.optionsContainer = container;
+    this.optionsListText = list;
+    this.optionsHintText = hint;
+    this.optionsHintBase = baseHint;
+  }
+
+  installInputHandlers() {
+    this.navKeys = this.input.keyboard.addKeys({
+      up: Phaser.Input.Keyboard.KeyCodes.UP,
+      down: Phaser.Input.Keyboard.KeyCodes.DOWN,
+      left: Phaser.Input.Keyboard.KeyCodes.LEFT,
+      right: Phaser.Input.Keyboard.KeyCodes.RIGHT,
+      esc: Phaser.Input.Keyboard.KeyCodes.ESC,
+      enter: Phaser.Input.Keyboard.KeyCodes.ENTER,
+      one: Phaser.Input.Keyboard.KeyCodes.ONE,
+      two: Phaser.Input.Keyboard.KeyCodes.TWO,
+      three: Phaser.Input.Keyboard.KeyCodes.THREE,
+      four: Phaser.Input.Keyboard.KeyCodes.FOUR
+    });
+    this.input.keyboard.on("keydown", this.handleGlobalKeydown, this);
+  }
+
+  update() {
+    if (this.inventoryVisible) {
+      this.handleInventoryInput();
+    }
+    if (this.optionsVisible) {
+      this.handleOptionsInput();
+    }
+  }
+
+  handleStateUpdate(payload) {
+    if (!payload) {
+      return;
+    }
+
+    if (payload.hud) {
+      this.updateHud(payload.hud);
+    }
+    if (payload.performance) {
+      this.updatePerformance(payload.performance);
+    }
+    if (payload.quickSlots) {
+      this.quickSlotData = payload.quickSlots;
+      this.updateQuickSlots();
+    }
+    if (payload.inventory) {
+      this.inventoryData = payload.inventory;
+      if (this.inventoryVisible) {
+        this.refreshInventoryList();
+      }
+    }
+    if (payload.options) {
+      this.optionsState = { ...this.optionsState, ...payload.options };
+      if (this.optionsVisible) {
+        this.refreshOptionsList();
+      }
+    }
+    if (payload.bindings) {
+      this.setBindingState(payload.bindings);
+    }
+    if (payload.map) {
+      this.updateMiniMap(payload.map);
+    }
+    if (payload.menu) {
+      this.handleMenuState(payload.menu);
+      this.syncPanelsFromMenu(payload.menu);
+    }
+  }
+
+  syncPanelsFromMenu(menuState) {
+    if (!menuState) {
+      return;
+    }
+
+    if (menuState.inventoryOpen !== undefined && this.inventoryContainer) {
+      const shouldOpen = Boolean(menuState.inventoryOpen);
+      if (this.inventoryVisible !== shouldOpen) {
+        this.inventoryVisible = shouldOpen;
+        this.inventoryContainer.setVisible(shouldOpen);
+        if (shouldOpen) {
+          this.inventorySelectionIndex = Phaser.Math.Clamp(
+            this.inventorySelectionIndex,
+            0,
+            Math.max(0, this.inventoryData.length - 1)
+          );
+          this.refreshInventoryList();
+        }
+      }
+    }
+
+    if (menuState.optionsOpen !== undefined && this.optionsContainer) {
+      const shouldOpen = Boolean(menuState.optionsOpen);
+      if (this.optionsVisible !== shouldOpen) {
+        this.optionsVisible = shouldOpen;
+        this.optionsContainer.setVisible(shouldOpen);
+        if (shouldOpen) {
+          this.refreshOptionsList();
+        } else {
+          this.cancelBindingCapture();
+        }
+      }
+    }
+  }
+
+  handlePanelToggle({ panel, open }) {
+    if (panel === "inventory") {
+      this.inventoryVisible = open;
+      this.inventoryContainer.setVisible(open);
+      if (open) {
+        this.inventorySelectionIndex = Phaser.Math.Clamp(this.inventorySelectionIndex, 0, Math.max(0, this.inventoryData.length - 1));
+        this.refreshInventoryList();
+      }
+    } else if (panel === "options") {
+      this.optionsVisible = open;
+      this.optionsContainer.setVisible(open);
+      if (open) {
+        this.refreshOptionsList();
+      } else {
+        this.cancelBindingCapture();
+      }
+    }
+  }
+
+  handleMenuState({ open }) {
+    const alpha = open ? 0.45 : 1;
+    if (this.hud) {
+      this.hud.container.setAlpha(alpha);
+    }
+    if (this.quickSlotContainer) {
+      this.quickSlotContainer.setAlpha(open ? 0.6 : 1);
+    }
+  }
+
+  setBindingState(bindings) {
+    if (!Array.isArray(bindings)) {
+      this.bindingState = [];
+      this.bindingLookup = new Map();
+      return;
+    }
+    this.bindingState = bindings;
+    this.bindingLookup = new Map();
+    bindings.forEach((entry) => {
+      if (entry && entry.action) {
+        this.bindingLookup.set(entry.action, entry);
+      }
+    });
+    if (this.optionsVisible) {
+      this.refreshOptionsList();
+    }
+  }
+
+  updateHud(hudState) {
+    const hpRatio = hudState.maxHp > 0 ? Phaser.Math.Clamp(hudState.hp / hudState.maxHp, 0, 1) : 0;
+    const mpRatio = hudState.maxMp > 0 ? Phaser.Math.Clamp(hudState.mp / hudState.maxMp, 0, 1) : 0;
+
+    this.hud.hpFill.displayWidth = this.hpBarWidth * hpRatio;
+    this.hud.hpText.setText(`${hudState.hp} / ${hudState.maxHp}`);
+    this.hud.mpFill.displayWidth = this.mpBarWidth * mpRatio;
+    this.hud.mpText.setText(`${hudState.mp} / ${hudState.maxMp}`);
+    this.hud.dashText.setText(hudState.dashReady ? "Dash Ready" : `Dash Cooldown ${Math.ceil(hudState.dashCooldown / 60)}f`);
+  }
+
+  updatePerformance(performance) {
+    const fps = performance && typeof performance.fps === "number" ? performance.fps : 0;
+    const frameTime = performance && typeof performance.frameTime === "number" ? performance.frameTime : 0;
+    const lines = [
+      `FPS ${fps.toFixed(0)}`,
+      `Frame ${frameTime.toFixed(1)} ms`,
+      `Objects ${performance.objects}`,
+      `Mobs ${performance.mobs}`,
+      `Projectiles ${performance.projectiles}`
+    ];
+    this.performanceText.setText(lines);
+  }
+
+  updateQuickSlots() {
+    this.quickSlotVisuals.forEach((visual) => {
+      visual.frame.setFillStyle(0x151b2a, 0.8);
+      visual.label.setText("--");
+      visual.quantity.setText("");
+    });
+
+    this.quickSlotData.forEach((slot, index) => {
+      const visual = this.quickSlotVisuals[index];
+      if (!visual || !slot || !slot.itemId) {
+        return;
+      }
+      visual.frame.setFillStyle(0x1f273a, 0.9);
+      const name = slot.name || "--";
+      visual.label.setText(name.length > 9 ? `${name.slice(0, 8)}...` : name);
+      visual.quantity.setText(slot.quantity > 1 ? `x${slot.quantity}` : "");
+    });
+  }
+
+  updateMiniMap(mapState) {
+    const graphics = this.miniMapGraphics;
+    if (!graphics) {
+      return;
+    }
+
+    graphics.clear();
+    graphics.fillStyle(0x0f1423, 0.9);
+    graphics.fillRect(0, 0, MINI_MAP_SIZE.width, MINI_MAP_SIZE.height);
+
+    if (!mapState || !mapState.width || !mapState.height) {
+      return;
+    }
+
+    const scale = Math.min(MINI_MAP_SIZE.width / mapState.width, MINI_MAP_SIZE.height / mapState.height);
+    const offsetX = (MINI_MAP_SIZE.width - mapState.width * scale) * 0.5;
+    const offsetY = (MINI_MAP_SIZE.height - mapState.height * scale) * 0.5;
+
+    function drawPoint(color, x, y, size) {
+      const pointSize = typeof size === "number" ? size : 4;
+      graphics.fillStyle(color, 1);
+      graphics.fillRect(
+        offsetX + x * scale - pointSize * 0.5,
+        offsetY + y * scale - pointSize * 0.5,
+        pointSize,
+        pointSize
+      );
+    }
+
+    if (mapState.player) {
+      drawPoint(0x6cf1ff, mapState.player.x, mapState.player.y, 6);
+    }
+    if (Array.isArray(mapState.mobs)) {
+      for (let i = 0; i < mapState.mobs.length; i += 1) {
+        const mob = mapState.mobs[i];
+        if (mob) {
+          drawPoint(0xff915d, mob.x, mob.y, 4);
+        }
+      }
+    }
+
+    if (mapState.camera) {
+      graphics.lineStyle(1, 0xffffff, 0.7);
+      graphics.strokeRect(
+        offsetX + mapState.camera.x * scale,
+        offsetY + mapState.camera.y * scale,
+        mapState.camera.width * scale,
+        mapState.camera.height * scale
+      );
+    }
+  }
+
+  handleInventoryInput() {
+    const hasItems = this.inventoryData.length > 0;
+
+    if (hasItems) {
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.up)) {
+        this.inventorySelectionIndex = Phaser.Math.Wrap(
+          this.inventorySelectionIndex - 1,
+          0,
+          Math.max(1, this.inventoryData.length)
+        );
+        this.refreshInventoryList();
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.down)) {
+        this.inventorySelectionIndex = Phaser.Math.Wrap(
+          this.inventorySelectionIndex + 1,
+          0,
+          Math.max(1, this.inventoryData.length)
+        );
+        this.refreshInventoryList();
+      }
+
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.one)) {
+        this.assignQuickSlot(0);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.two)) {
+        this.assignQuickSlot(1);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.three)) {
+        this.assignQuickSlot(2);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.four)) {
+        this.assignQuickSlot(3);
+      }
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.esc)) {
+      this.emitGameEvent("ui-close-panel", { panel: "inventory" });
+    }
+  }
+
+  handleOptionsInput() {
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.esc)) {
+      if (this.bindingListenAction) {
+        this.cancelBindingCapture();
+      } else {
+        this.emitGameEvent("ui-close-panel", { panel: "options" });
+      }
+      return;
+    }
+
+    if (this.bindingListenAction) {
+      return;
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.up)) {
+      this.optionsSelectionIndex = Phaser.Math.Wrap(this.optionsSelectionIndex - 1, 0, this.optionsConfig.length);
+      this.refreshOptionsList();
+    } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.down)) {
+      this.optionsSelectionIndex = Phaser.Math.Wrap(this.optionsSelectionIndex + 1, 0, this.optionsConfig.length);
+      this.refreshOptionsList();
+    }
+
+    const config = this.optionsConfig[this.optionsSelectionIndex];
+    if (!config) {
+      return;
+    }
+
+    if (config.type === "range" || config.type === "choice") {
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.left)) {
+        this.modifyOption(-1);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.right)) {
+        this.modifyOption(1);
+      }
+    } else if (config.type === "binding") {
+      if (
+        Phaser.Input.Keyboard.JustDown(this.navKeys.left) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.right) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.enter)
+      ) {
+        this.beginBindingCapture(config);
+      }
+    } else if (config.type === "action") {
+      if (
+        Phaser.Input.Keyboard.JustDown(this.navKeys.left) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.right) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.enter)
+      ) {
+        this.triggerOptionAction(config);
+      }
+    }
+  }
+
+  assignQuickSlot(slotIndex) {
+    if (!this.inventoryData.length) {
+      return;
+    }
+    const item = this.inventoryData[this.inventorySelectionIndex];
+    if (!item) {
+      return;
+    }
+    this.emitGameEvent("ui-assign-quick-slot", { slotIndex, itemId: item.id });
+  }
+
+  modifyOption(direction) {
+    const config = this.optionsConfig[this.optionsSelectionIndex];
+    if (!config || (config.type !== "range" && config.type !== "choice")) {
+      return;
+    }
+    const state = this.optionsState || {};
+    const hasCurrent = Object.prototype.hasOwnProperty.call(state, config.key);
+    const current = hasCurrent ? state[config.key] : undefined;
+    let nextValue = current;
+
+    if (config.type === "range") {
+      const step = typeof config.step === "number" ? config.step : 0.1;
+      const baseValue = typeof current === "number" ? current : config.min;
+      nextValue = Phaser.Math.Clamp(baseValue + step * direction, config.min, config.max);
+    } else if (config.type === "choice") {
+      const list = Array.isArray(config.values) ? config.values : [];
+      if (list.length === 0) {
+        return;
+      }
+      const fallback = list[0];
+      const currentIndex = Math.max(0, list.indexOf(hasCurrent ? current : fallback));
+      const nextIndex = Phaser.Math.Wrap(currentIndex + direction, 0, list.length);
+      nextValue = list[nextIndex];
+    }
+
+    this.optionsState = Object.assign({}, state, { [config.key]: nextValue });
+    this.refreshOptionsList();
+    this.emitGameEvent("ui-options-change", { [config.key]: nextValue });
+  }
+
+  beginBindingCapture(config) {
+    if (!config || !config.action) {
+      return;
+    }
+    this.bindingListenAction = config.action;
+    this.bindingListenLabel = config.label ? config.label : config.action;
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(
+        `${this.bindingListenLabel} - \uc0c8 \ud0a4 \uc785\ub825 (ESC \ucde8\uc18c)`
+      );
+    }
+    this.refreshOptionsList();
+  }
+
+  cancelBindingCapture() {
+    if (!this.bindingListenAction) {
+      return;
+    }
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(this.optionsHintBase);
+    }
+    this.refreshOptionsList();
+  }
+
+  completeBindingCapture(keyCode) {
+    const action = this.bindingListenAction;
+    if (!action) {
+      return;
+    }
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(this.optionsHintBase);
+    }
+    this.emitGameEvent("ui-rebind-action", { action, keyCode });
+    this.refreshOptionsList();
+  }
+
+  triggerOptionAction(config) {
+    if (!config) {
+      return;
+    }
+    if (config.action === "reset-bindings") {
+      this.cancelBindingCapture();
+      this.emitGameEvent("ui-reset-bindings");
+    }
+  }
+
+  handleGlobalKeydown(event) {
+    if (!this.bindingListenAction) {
+      return;
+    }
+    if (event.repeat) {
+      return;
+    }
+    if (event.key === "Escape" || event.key === "Esc") {
+      this.cancelBindingCapture();
+      return;
+    }
+    const keyCode = typeof event.keyCode === "number" ? event.keyCode : event.which;
+    if (typeof keyCode !== "number" || !Number.isFinite(keyCode)) {
+      return;
+    }
+    if (typeof event.preventDefault === "function") {
+      event.preventDefault();
+    }
+    if (typeof event.stopPropagation === "function") {
+      event.stopPropagation();
+    }
+    this.completeBindingCapture(keyCode);
+  }
+
+  refreshInventoryList() {
+    if (!this.inventoryData.length) {
+      this.inventoryListText.setText(["(\uc544\uc774\ud15c \uc5c6\uc74c)"]);
+      this.inventoryDetailText.setText("\uc804\ub9ac\ud488\uc744 \ud68d\ub4dd\ud574 \uc778\ubca4\ud1a0\ub9ac\ub97c \ucc44\uc6b0\uc138\uc694.");
+      return;
+    }
+
+    this.inventorySelectionIndex = Phaser.Math.Clamp(this.inventorySelectionIndex, 0, this.inventoryData.length - 1);
+
+    const quickSlotMap = new Map();
+    this.quickSlotData.forEach((slot) => {
+      if (slot && slot.itemId) {
+        quickSlotMap.set(slot.itemId, slot.index + 1);
+      }
+    });
+
+    const lines = this.inventoryData.map((item, index) => {
+      const selector = index === this.inventorySelectionIndex ? "\u25b6" : " ";
+      const slotTag = quickSlotMap.has(item.id) ? ` [${quickSlotMap.get(item.id)}]` : "";
+      return `${selector} ${item.name}${slotTag}  x${item.quantity}`;
+    });
+
+    this.inventoryListText.setText(lines);
+    const selected = this.inventoryData[this.inventorySelectionIndex];
+    const detailText = selected && selected.description ? selected.description : "\uc0c1\uc138 \uc124\uba85\uc774 \uc5c6\uc2b5\ub2c8\ub2e4.";
+    this.inventoryDetailText.setText(detailText);
+  }
+
+  refreshOptionsList() {
+    const lines = this.optionsConfig.map((config, index) => {
+      const selector = index === this.optionsSelectionIndex ? "\u25b6" : " ";
+      if (config.type === "action") {
+        const suffix = config.action === "reset-bindings" ? " (Enter)" : "";
+        return `${selector} ${config.label}${suffix}`;
+      }
+      const value = this.formatOptionValue(config);
+      return `${selector} ${config.label}: ${value}`;
+    });
+    this.optionsListText.setText(lines);
+  }
+
+  formatOptionValue(config) {
+    if (config.type === "binding") {
+      if (this.bindingListenAction === config.action) {
+        return "[\uc785\ub825 \ub300\uae30]";
+      }
+      return this.formatBindingValue(config.action);
+    }
+    if (config.type === "action") {
+      return "";
+    }
+    const state = this.optionsState || {};
+    const hasValue = Object.prototype.hasOwnProperty.call(state, config.key);
+    const value = hasValue ? state[config.key] : undefined;
+    if (config.type === "range") {
+      if (config.key === "resolutionScale") {
+        const scale = typeof value === "number" ? value : 1;
+        return `${Math.round(scale * 100)}%`;
+      }
+      const numeric = typeof value === "number" ? value : 0;
+      return `${Math.round(numeric * 100)}%`;
+    }
+    if (config.type === "choice") {
+      const list = Array.isArray(config.values) ? config.values : [];
+      if (hasValue) {
+        return value;
+      }
+      return list.length > 0 ? list[0] : "";
+    }
+    if (hasValue && value != null) {
+      return value;
+    }
+    const defaults = Array.isArray(config.values) ? config.values : [];
+    return defaults.length > 0 ? defaults[0] : "";
+  }
+
+  formatBindingValue(action) {
+    if (!action) {
+      return "--";
+    }
+    const entry = this.bindingLookup.get(action);
+    if (!entry) {
+      return "--";
+    }
+    if (Array.isArray(entry.labels) && entry.labels.length) {
+      return entry.labels.join(" / ");
+    }
+    if (Array.isArray(entry.codes) && entry.codes.length) {
+      return entry.codes.map((code) => String(code)).join(" / ");
+    }
+    return "--";
+  }
+
+  createOptionsConfig() {
+    return [
+      { key: "masterVolume", label: "Master Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "sfxVolume", label: "SFX Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "bgmVolume", label: "BGM Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "resolutionScale", label: "Resolution Scale", type: "range", min: 0.7, max: 1.1, step: 0.05 },
+      { key: "graphicsQuality", label: "Graphics Quality", type: "choice", values: ["High", "Performance"] },
+      { key: "bind.moveLeft", label: "Move Left", type: "binding", action: INPUT_KEYS.LEFT },
+      { key: "bind.moveRight", label: "Move Right", type: "binding", action: INPUT_KEYS.RIGHT },
+      { key: "bind.moveUp", label: "Move Up", type: "binding", action: INPUT_KEYS.UP },
+      { key: "bind.moveDown", label: "Move Down", type: "binding", action: INPUT_KEYS.DOWN },
+      { key: "bind.jump", label: "Jump", type: "binding", action: INPUT_KEYS.JUMP },
+      { key: "bind.dash", label: "Dash", type: "binding", action: INPUT_KEYS.DASH },
+      { key: "bind.attackPrimary", label: "Primary Attack", type: "binding", action: INPUT_KEYS.ATTACK_PRIMARY },
+      { key: "bind.attackSecondary", label: "Secondary Attack", type: "binding", action: INPUT_KEYS.ATTACK_SECONDARY },
+      { key: "bind.interact", label: "Interact", type: "binding", action: INPUT_KEYS.INTERACT },
+      { key: "bind.inventory", label: "Inventory Menu", type: "binding", action: INPUT_KEYS.INVENTORY },
+      { key: "bind.options", label: "Options Menu", type: "binding", action: INPUT_KEYS.OPTIONS },
+      { key: "resetBindings", label: "Reset Key Bindings", type: "action", action: "reset-bindings" }
+    ];
+  }
+
+  getLabelStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "16px",
+      color: "#9ca6cf"
+    };
+  }
+
+  getValueStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "18px",
+      color: "#f5f6ff"
+    };
+  }
+
+  getHintStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "14px",
+      color: "#9ca6cf"
+    };
+  }
+
+  getTitleStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "24px",
+      color: "#f7f8ff"
+    };
+  }
+
+  shutdown() {
+    if (this.gameScene && this.gameScene.events) {
+      this.gameScene.events.off("ui-state", this.handleStateUpdate, this);
+      this.gameScene.events.off("ui-panel", this.handlePanelToggle, this);
+      this.gameScene.events.off("ui-menu-state", this.handleMenuState, this);
+    }
+    this.cancelBindingCapture();
+    if (this.input && this.input.keyboard) {
+      this.input.keyboard.off("keydown", this.handleGlobalKeydown, this);
+    }
+    this.gameScene = null;
+  }
+}

--- a/phaser-vertical-slice/src/systems/AssetLoader.js
+++ b/phaser-vertical-slice/src/systems/AssetLoader.js
@@ -1,6 +1,19 @@
-﻿import Phaser from "../phaser.js";
+import Phaser from "../phaser.js";
 
-const ASSET_BASE_PATH = "public";
+function resolveAssetBasePath() {
+  if (typeof window !== "undefined" && window.location) {
+    try {
+      const resolved = new URL("./public/", window.location.href);
+      return resolved.pathname.replace(/\/+$/, "");
+    } catch (err) {
+      console.warn("[Skywood] Failed to resolve public asset path, falling back.", err);
+    }
+  }
+
+  return "public";
+}
+
+const ASSET_BASE_PATH = resolveAssetBasePath();
 
 export const ASSET_KEYS = Object.freeze({
   ATLAS: {

--- a/phaser-vertical-slice/src/systems/AudioManager.js
+++ b/phaser-vertical-slice/src/systems/AudioManager.js
@@ -1,20 +1,42 @@
-﻿export default class AudioManager {
+import Phaser from "../phaser.js";
+
+export default class AudioManager {
   constructor(scene) {
     this.scene = scene;
+    this.masterVolume = 0.8;
+    this.sfxVolume = 0.9;
+    this.bgmVolume = 0.7;
+    this.currentBgm = null;
   }
 
   play(key, spriteKey) {
     if (!this.scene.sound || this.scene.sound.locked) {
       return;
     }
+    const volume = Phaser.Math.Clamp(this.masterVolume * this.sfxVolume, 0, 1);
     try {
       if (spriteKey) {
-        this.scene.sound.playAudioSprite(key, spriteKey, { volume: 0.6 });
+        this.scene.sound.playAudioSprite(key, spriteKey, { volume });
       } else {
-        this.scene.sound.play(key, { volume: 0.6 });
+        this.scene.sound.play(key, { volume });
       }
     } catch (error) {
       // ignore play failure
+    }
+  }
+
+  applyMixSettings(patch = {}) {
+    if (patch.masterVolume !== undefined) {
+      this.masterVolume = Phaser.Math.Clamp(patch.masterVolume, 0, 1);
+    }
+    if (patch.sfxVolume !== undefined) {
+      this.sfxVolume = Phaser.Math.Clamp(patch.sfxVolume, 0, 1);
+    }
+    if (patch.bgmVolume !== undefined) {
+      this.bgmVolume = Phaser.Math.Clamp(patch.bgmVolume, 0, 1);
+      if (this.currentBgm) {
+        this.currentBgm.setVolume(this.masterVolume * this.bgmVolume);
+      }
     }
   }
 }

--- a/phaser-vertical-slice/src/systems/InputManager.js
+++ b/phaser-vertical-slice/src/systems/InputManager.js
@@ -30,6 +30,26 @@ const DEFAULT_KEYMAP = {
 
 const keyStateCache = new Map();
 
+const KEYCODE_TO_NAME = Object.entries(Phaser.Input.Keyboard.KeyCodes).reduce((acc, [name, code]) => {
+  if (typeof code === "number" && acc[code] === undefined) {
+    acc[code] = name;
+  }
+  return acc;
+}, {});
+
+const SPECIAL_KEY_LABELS = {
+  SPACE: "Space",
+  ESC: "Esc",
+  ESCAPE: "Esc",
+  LEFT: "Left",
+  RIGHT: "Right",
+  UP: "Up",
+  DOWN: "Down",
+  PAGE_UP: "Page Up",
+  PAGE_DOWN: "Page Down",
+  PRINT_SCREEN: "Print Screen"
+};
+
 function resolveKeyCode(code) {
   if (typeof code === "number") {
     return code;
@@ -38,11 +58,29 @@ function resolveKeyCode(code) {
   return keyCode ?? code;
 }
 
+function formatKeyLabel(code) {
+  if (typeof code !== "number") {
+    return String(code);
+  }
+  const name = KEYCODE_TO_NAME[code];
+  if (!name) {
+    return `Key ${code}`;
+  }
+  if (SPECIAL_KEY_LABELS[name]) {
+    return SPECIAL_KEY_LABELS[name];
+  }
+  return name
+    .split("_")
+    .map((segment) => segment.charAt(0) + segment.slice(1).toLowerCase())
+    .join(" ");
+}
+
 export default class InputManager {
   constructor(scene) {
     this.scene = scene;
     this.keyboard = scene.input.keyboard;
     this.bindings = new Map();
+    this.bindingCodes = new Map();
     this.justPressed = new Set();
     this.justReleased = new Set();
 
@@ -59,11 +97,7 @@ export default class InputManager {
   }
 
   installDefaults() {
-    Object.entries(DEFAULT_KEYMAP).forEach(([action, keys]) => {
-      const keyObjects = keys.map((code) => this.keyboard.addKey(resolveKeyCode(code)));
-      this.bindings.set(action, keyObjects);
-      keyStateCache.set(action, false);
-    });
+    this.resetAllBindings();
   }
 
   handleUpdate() {
@@ -115,12 +149,83 @@ export default class InputManager {
     return this.justReleased.has(action);
   }
 
+  resetAll() {
+    this.resetKeys();
+  }
+
+  setBinding(action, codes) {
+    const uniqueCodes = Array.from(
+      new Set(
+        (codes || [])
+          .map((code) => resolveKeyCode(code))
+          .filter((value) => typeof value === "number" && Number.isFinite(value))
+      )
+    );
+
+    const existing = this.bindings.get(action);
+    if (existing) {
+      existing.forEach((key) => key.destroy());
+    }
+
+    const keyObjects = uniqueCodes.map((code) => this.keyboard.addKey(code));
+    this.bindings.set(action, keyObjects);
+    this.bindingCodes.set(action, uniqueCodes);
+    keyStateCache.set(action, false);
+    this.justPressed.delete(action);
+    this.justReleased.delete(action);
+  }
+
+  rebindAction(action, primaryCode) {
+    if (!action) {
+      return false;
+    }
+    const resolved = resolveKeyCode(primaryCode);
+    if (typeof resolved !== "number" || !Number.isFinite(resolved)) {
+      return false;
+    }
+
+    const defaults = DEFAULT_KEYMAP[action] ?? [];
+    const fallback = defaults.slice(1);
+    this.setBinding(action, [resolved, ...fallback]);
+    return true;
+  }
+
+  getBindingSnapshot() {
+    return Array.from(this.bindingCodes.entries()).map(([action, codes]) => ({
+      action,
+      codes: [...codes],
+      labels: codes.map((code) => formatKeyLabel(code))
+    }));
+  }
+
+  resetBindingsToDefault(action) {
+    if (!action || !DEFAULT_KEYMAP[action]) {
+      return false;
+    }
+    this.setBinding(action, DEFAULT_KEYMAP[action]);
+    return true;
+  }
+
+  resetAllBindings() {
+    this.bindings.forEach((keys) => keys.forEach((key) => key.destroy()));
+    this.bindings.clear();
+    this.bindingCodes.clear();
+    keyStateCache.clear();
+    this.justPressed.clear();
+    this.justReleased.clear();
+
+    Object.entries(DEFAULT_KEYMAP).forEach(([action, keys]) => {
+      this.setBinding(action, keys);
+    });
+  }
+
   destroy() {
     this.scene.events.off(Phaser.Scenes.Events.UPDATE, this.handleUpdate, this);
     this.scene.game.events.off(Phaser.Core.Events.BLUR, this.handleBlur, this);
     this.scene.game.events.off(Phaser.Core.Events.FOCUS, this.handleFocus, this);
     this.bindings.forEach((keys) => keys.forEach((key) => key.destroy()));
     this.bindings.clear();
+    this.bindingCodes.clear();
     keyStateCache.clear();
   }
 }


### PR DESCRIPTION
## Summary
- default the UI scene key safely and add an internal helper for emitting game-scene events
- replace optional chaining and nullish-coalescing usage across inventory and options handlers with guarded logic
- normalize option formatting and binding capture fallbacks so the script parses on older browsers
- guard the minimap graphics helper and replace the arrow default parameter so legacy parsers no longer choke on `=> {`

## Testing
- node --check phaser-vertical-slice/src/scenes/UIScene.js
- find src -name '*.js' -print0 | xargs -0 -n1 node --check

------
https://chatgpt.com/codex/tasks/task_e_68cad606aac0832b94fbed009ad0b8bd