### PR TITLE
Extend player i-frames and stabilize dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# chatgpt
+# Skywood Legends Slice
+
+Skywood Legends Slice is a Phaser 3 + Matter.js vertical slice that emulates a high-performance "MapleStory-style" action RPG. The project targets 60 FPS gameplay, responsive controls, and minimal garbage collection pressure while running entirely in the browser.
+
+## Repository Layout
+
+```
+phaser-vertical-slice/
+  index.html               # Entry point that bootstraps Phaser in module mode
+  public/                  # Static assets (placeholder art, audio sprite, tilemaps)
+  src/                     # Game source (scenes, entities, systems)
+```
+
+## Getting Started
+
+1. Install any static HTTP server you prefer. Python is preinstalled in the container, so the simplest option is:
+   ```bash
+   cd phaser-vertical-slice
+   python3 -m http.server 5173
+   ```
+2. In Codex Web (or your local browser) open the forwarded preview URL and append `/index.html`, e.g. `https://<preview-host>/index.html`.
+3. The game auto-loads assets and starts in the GameScene. Press `I` for the inventory, `O` for the options menu, and `F8` for the bug report overlay.
+
+Phaser is loaded via the local `public/vendor/phaser.esm.js` bundle with a CDN fallback, so no package installation is required.
+
+## Build & Deployment Notes
+
+- The project is fully static. To deploy, copy the `phaser-vertical-slice` directory to any static web host (GitHub Pages, Netlify, etc.). Ensure the host serves the directory root so `/public/...` asset URLs resolve correctly.
+- When serving from a subdirectory, keep the folder structure intact (`index.html` next to `public/` and `src/`). The asset loader derives absolute paths from the current page URL, so no additional configuration is needed.
+- For production hosting, enable HTTP compression where possible; the asset bundle is composed of lightweight placeholder textures and audio sprites.
+
+## Save System
+
+- Progress (player position, HP/MP, inventory, quick slots, options, key bindings) is saved automatically to `localStorage` under the key `skywood.save.slot0`.
+- Autosave triggers after any menu change (inventory/options/bindings), player damage, and every 15 seconds during gameplay. A status banner appears in the lower-left HUD and the bug report overlay includes the latest save information.
+- If the browser blocks storage (private mode, quota exceeded), the UI shows a warning so you can notify QA or adjust permissions.
+
+## Debug & QA Tools
+
+- **Performance HUD:** Displays FPS, frame time, live object count, mob visibility, projectile totals, and pool usage to help maintain the 16.7 ms frame budget.
+- **Bug Report Overlay:** Press `F8` to open an in-game checklist for reporting issues. The overlay summarises the latest save status and reminders for reproducible bug reports.
+- **PerfMeter Overlay:** The in-game PerfMeter (top-left) mirrors core metrics for quick profiling during development.
+
+## Default Controls
+
+- Move: Arrow keys or `A/D`
+- Jump: `Space` or `W`
+- Dash: `Shift`
+- Primary / Secondary attack: `J` / `K`
+- Interact: `E`
+- Inventory: `I`
+- Options: `O`
+
+All bindings can be remapped from the options menu; resets and new bindings are persisted automatically.

--- a/phaser-vertical-slice/src/entities/Mob.js
+++ b/phaser-vertical-slice/src/entities/Mob.js
@@ -35,6 +35,7 @@ export default class Mob extends Phaser.Physics.Matter.Sprite {
     this.stats = new CombatStats({ maxHP: MOB_CONFIG.maxHP, maxMP: 0 });
     this.hitstunTimer = 0;
     this.knockback = { x: 0, y: 0 };
+    this.isCulled = false;
 
     const body = Bodies.rectangle(0, 0, MOB_CONFIG.width, MOB_CONFIG.height, {
       chamfer: { radius: 6 }
@@ -78,6 +79,7 @@ export default class Mob extends Phaser.Physics.Matter.Sprite {
     this.setAwake(true);
     this.setActive(true);
     this.setVisible(true);
+    this.isCulled = false;
   }
 
   sleepOffscreen() {
@@ -85,12 +87,15 @@ export default class Mob extends Phaser.Physics.Matter.Sprite {
     this.setVelocity(0, 0);
     this.setActive(false);
     this.setVisible(false);
+    this.isCulled = false;
   }
 
   update(time, delta) {
     if (!this.active || !this.body) {
       return;
     }
+
+    this.stats.update(delta);
 
     switch (this.state) {
       case "patrol":

--- a/phaser-vertical-slice/src/main.js
+++ b/phaser-vertical-slice/src/main.js
@@ -2,6 +2,7 @@
 import BootScene from "./scenes/BootScene.js";
 import PreloadScene from "./scenes/PreloadScene.js";
 import GameScene from "./scenes/GameScene.js";
+import UIScene from "./scenes/UIScene.js";
 
 const GAME_WIDTH = 1280;
 const GAME_HEIGHT = 720;
@@ -43,7 +44,7 @@ const config = {
     min: 30,
     forceSetTimeOut: false
   },
-  scene: [BootScene, PreloadScene, GameScene]
+  scene: [BootScene, PreloadScene, GameScene, UIScene]
 };
 
 function bootGame() {

--- a/phaser-vertical-slice/src/scenes/GameScene.js
+++ b/phaser-vertical-slice/src/scenes/GameScene.js
@@ -1,15 +1,21 @@
-﻿import Phaser from "../phaser.js";
+import Phaser from "../phaser.js";
 import PerfMeter from "../systems/PerfMeter.js";
-import AssetLoader, { ASSET_KEYS } from "../systems/AssetLoader.js";
+import { ASSET_KEYS } from "../systems/AssetLoader.js";
 import InputManager, { INPUT_KEYS } from "../systems/InputManager.js";
 import Player from "../entities/Player.js";
 import Pool from "../systems/Pool.js";
 import AudioManager from "../systems/AudioManager.js";
 import Projectile from "../entities/Projectile.js";
 import Spawner from "../systems/Spawner.js";
+import SaveManager from "../systems/SaveManager.js";
 
 const CAMERA_DEADZONE_X = 0.4;
 const CAMERA_DEADZONE_Y = 0.3;
+const UI_SYNC_INTERVAL = 120;
+const SAVE_DEBOUNCE_MS = 800;
+const SAVE_RETRY_MS = 4000;
+const AUTO_SAVE_INTERVAL = 15000;
+const PROJECTILE_CULL_PADDING = 220;
 
 export default class GameScene extends Phaser.Scene {
   constructor() {
@@ -21,15 +27,46 @@ export default class GameScene extends Phaser.Scene {
     this.parallaxConfig = [];
     this.inputManager = null;
     this.player = null;
-    this.debugHud = null;
     this.audio = null;
     this.projectilePool = null;
     this.projectiles = new Set();
+    this.damageTextPool = null;
+    this.lootPool = null;
     this.mobSpawner = null;
+
+    this.saveManager = null;
+    this.restoredData = null;
+    this.saveDirty = false;
+    this.saveCooldown = 0;
+    this.autoSaveTimer = 0;
+    this.lastSaveStatus = { state: "idle", timestamp: 0 };
+    this.lastSaveReason = "startup";
+    this.systemDirty = true;
+
+    this.inventory = [];
+    this.quickSlots = [];
+    this.optionsState = {};
+    this.bindingsDirty = false;
+    this.inventoryDirty = false;
+    this.quickSlotsDirty = false;
+    this.optionsDirty = false;
+    this.uiSyncTimer = 0;
+    this.menuState = { inventoryOpen: false, optionsOpen: false };
+    this.menuOpen = false;
+    this.lastFrameTime = 0;
   }
 
   create() {
     this.cameras.main.setBackgroundColor("#2a2f3a");
+
+    this.saveManager = new SaveManager();
+    this.restoredData = this.saveManager.load();
+    if (!this.saveManager.isAvailable()) {
+      this.lastSaveStatus = { state: "disabled", timestamp: Date.now() };
+    } else if (this.restoredData && typeof this.restoredData.timestamp === "number") {
+      this.lastSaveStatus = { state: "success", timestamp: this.restoredData.timestamp };
+    }
+    this.systemDirty = true;
 
     this.inputManager = new InputManager(this);
     this.audio = new AudioManager(this);
@@ -39,6 +76,7 @@ export default class GameScene extends Phaser.Scene {
 
     const spawn = this.getPlayerSpawn();
     this.player = new Player(this, spawn.x, spawn.y, this.inputManager);
+    this.applyRestoredPlayerState();
 
     this.projectilePool = new Pool(
       () => {
@@ -57,6 +95,8 @@ export default class GameScene extends Phaser.Scene {
       }
     );
 
+    this.createEffectPools();
+
     this.mobSpawner = new Spawner(this, {
       spawnX: spawn.x + 180,
       spawnY: spawn.y - 20,
@@ -64,9 +104,56 @@ export default class GameScene extends Phaser.Scene {
     });
 
     this.setupCamera();
-    this.createHud();
+
+    this.initializeGameData();
+    this.initializeUIBridge();
+
+    this.markProgressDirty("startup", true);
 
     this.perfMeter = new PerfMeter(this);
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.shutdown, this);
+  }
+
+  createEffectPools() {
+    this.damageTextPool = new Pool(
+      () => {
+        const text = this.add.text(0, 0, "", {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "18px",
+          color: "#ff5e5e"
+        });
+        text.setDepth(80);
+        text.setOrigin(0.5, 1);
+        text.setActive(false);
+        text.setVisible(false);
+        return text;
+      },
+      (text) => {
+        this.tweens.killTweensOf(text);
+        text.setAlpha(1);
+        text.setScale(1);
+        text.setActive(false);
+        text.setVisible(false);
+      }
+    );
+
+    this.lootPool = new Pool(
+      () => {
+        const rect = this.add.rectangle(0, 0, 12, 12, 0xffd166);
+        rect.setDepth(70);
+        rect.setActive(false);
+        rect.setVisible(false);
+        return rect;
+      },
+      (rect) => {
+        this.tweens.killTweensOf(rect);
+        rect.setAlpha(1);
+        rect.setScale(1);
+        rect.setActive(false);
+        rect.setVisible(false);
+      }
+    );
   }
 
   createParallax() {
@@ -117,6 +204,40 @@ export default class GameScene extends Phaser.Scene {
     this.matter.world.setBounds(0, 0, this.map.widthInPixels, this.map.heightInPixels);
   }
 
+  applyRestoredPlayerState() {
+    if (!this.player || !this.restoredData || !this.restoredData.player) {
+      return;
+    }
+    const data = this.restoredData.player;
+    const hasMap = Boolean(this.map);
+    const clampX = hasMap
+      ? Phaser.Math.Clamp(
+          typeof data.x === "number" ? data.x : this.player.x,
+          32,
+          Math.max(32, this.map.widthInPixels - 32)
+        )
+      : typeof data.x === "number"
+        ? data.x
+        : this.player.x;
+    const clampY = hasMap
+      ? Phaser.Math.Clamp(
+          typeof data.y === "number" ? data.y : this.player.y,
+          0,
+          Math.max(0, this.map.heightInPixels - 16)
+        )
+      : typeof data.y === "number"
+        ? data.y
+        : this.player.y;
+
+    this.player.setPosition(clampX, clampY);
+    if (typeof data.hp === "number") {
+      this.player.stats.hp = Phaser.Math.Clamp(Math.round(data.hp), 0, this.player.stats.maxHP);
+    }
+    if (typeof data.mp === "number") {
+      this.player.stats.mp = Phaser.Math.Clamp(Math.round(data.mp), 0, this.player.stats.maxMP);
+    }
+  }
+
   getPlayerSpawn() {
     if (!this.map) {
       return { x: this.scale.width * 0.5, y: this.scale.height * 0.5 };
@@ -164,28 +285,536 @@ export default class GameScene extends Phaser.Scene {
     }
   }
 
-  createHud() {
-    const hudText = this.add.text(20, 20, "", {
-      fontFamily: "Rubik, 'Segoe UI', sans-serif",
-      fontSize: "18px",
-      color: "#ffffff"
-    });
-    hudText.setScrollFactor(0);
-    hudText.setDepth(1001);
-    this.debugHud = hudText;
+  initializeGameData() {
+    const restore = this.restoredData || {};
+
+    const defaultInventory = [
+      {
+        id: "skyroot_tonic",
+        name: "Skyroot Tonic",
+        type: "consumable",
+        quantity: 3,
+        description: "Restores 40 HP over a short duration."
+      },
+      {
+        id: "azure_focus",
+        name: "Azure Focus",
+        type: "consumable",
+        quantity: 2,
+        description: "Instantly revitalises 30 MP."
+      },
+      {
+        id: "ember_shard",
+        name: "Ember Shard",
+        type: "material",
+        quantity: 5,
+        description: "Warm crystalline shard used for crafting combustion cores."
+      },
+      {
+        id: "wingburst_scroll",
+        name: "Wingburst Scroll",
+        type: "skill",
+        quantity: 1,
+        description: "Unlocks a temporary mid-air burst dash when consumed."
+      }
+    ];
+
+    const savedInventory = Array.isArray(restore.inventory) ? restore.inventory : null;
+    const sourceInventory = savedInventory && savedInventory.length ? savedInventory : defaultInventory;
+    this.inventory = sourceInventory.map((item) => ({
+      id: item.id,
+      name: item.name,
+      type: item.type || "consumable",
+      quantity: Number.isFinite(item.quantity) ? Math.max(0, Math.round(item.quantity)) : 1,
+      description: item.description || ""
+    }));
+
+    const defaultQuickSlots = [
+      { index: 0, itemId: "skyroot_tonic" },
+      { index: 1, itemId: "azure_focus" },
+      { index: 2, itemId: null },
+      { index: 3, itemId: "wingburst_scroll" }
+    ];
+    this.quickSlots = defaultQuickSlots.map((slot) => ({ ...slot }));
+    if (Array.isArray(restore.quickSlots)) {
+      restore.quickSlots.forEach((slot) => {
+        if (!slot || typeof slot.index !== "number") {
+          return;
+        }
+        const idx = slot.index;
+        if (idx < 0 || idx >= this.quickSlots.length) {
+          return;
+        }
+        const itemId = typeof slot.itemId === "string" ? slot.itemId : null;
+        this.quickSlots[idx] = { index: idx, itemId };
+      });
+    }
+
+    const inventoryIds = new Set(this.inventory.map((item) => item.id));
+    this.quickSlots = this.quickSlots.map((slot) => ({
+      index: slot.index,
+      itemId: slot.itemId && inventoryIds.has(slot.itemId) ? slot.itemId : null
+    }));
+
+    const defaultOptions = {
+      masterVolume: 0.8,
+      sfxVolume: 0.9,
+      bgmVolume: 0.7,
+      resolutionScale: 1,
+      graphicsQuality: "High"
+    };
+    this.optionsState = { ...defaultOptions, ...(restore.options || {}) };
+
+    this.inventoryDirty = true;
+    this.quickSlotsDirty = true;
+    this.optionsDirty = true;
+    this.bindingsDirty = true;
+
+    this.audio.applyMixSettings(this.optionsState);
+    this.updateResolutionScale();
+    this.applyGraphicsQuality(this.optionsState.graphicsQuality);
+
+    if (Array.isArray(restore.bindings) && this.inputManager?.applyBindingSnapshot) {
+      this.inputManager.applyBindingSnapshot(restore.bindings);
+      this.bindingsDirty = true;
+    }
+  }
+
+  initializeUIBridge() {
+    this.events.on("ui-options-change", this.applyOptionsPatch, this);
+    this.events.on("ui-assign-quick-slot", this.handleQuickSlotAssignment, this);
+    this.events.on("ui-close-panel", this.handleUIClosePanel, this);
+    this.events.on("ui-rebind-action", this.handleRebindAction, this);
+    this.events.on("ui-reset-bindings", this.handleResetBindings, this);
+    this.events.once("ui-ready", this.handleUIReady, this);
+
+    if (this.scene.isActive && this.scene.isActive("UIScene")) {
+      this.scene.stop("UIScene");
+    }
+    this.scene.launch("UIScene", { gameSceneKey: this.scene.key });
+    this.scene.bringToTop("UIScene");
+  }
+
+  handleUIReady() {
+    this.syncUI(true);
   }
 
   update(time, delta) {
+    this.lastFrameTime = delta;
     this.updateParallax();
-    this.updateHud();
-    this.handleCombatInput();
+    this.handleUtilityInput();
+
+    if (!this.menuOpen) {
+      this.handleCombatInput();
+    }
+
     this.mobSpawner?.update(time, delta);
     this.updateProjectiles();
     this.handleMobInteractions();
+    this.updateSaveHeartbeat(delta);
+    this.updateUIHeartbeat(delta);
+  }
+
+  handleUtilityInput() {
+    if (!this.inputManager) {
+      return;
+    }
+
+    if (this.inputManager.wasJustPressed(INPUT_KEYS.INVENTORY)) {
+      const open = !this.menuState.inventoryOpen;
+      this.menuState.inventoryOpen = open;
+      if (open && this.menuState.optionsOpen) {
+        this.menuState.optionsOpen = false;
+        this.events.emit("ui-panel", { panel: "options", open: false });
+      }
+      this.events.emit("ui-panel", { panel: "inventory", open });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+
+    if (this.inputManager.wasJustPressed(INPUT_KEYS.OPTIONS)) {
+      const open = !this.menuState.optionsOpen;
+      this.menuState.optionsOpen = open;
+      if (open && this.menuState.inventoryOpen) {
+        this.menuState.inventoryOpen = false;
+        this.events.emit("ui-panel", { panel: "inventory", open: false });
+      }
+      this.events.emit("ui-panel", { panel: "options", open });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+  }
+
+  handleMenuStateChanged() {
+    const isOpen = this.menuState.inventoryOpen || this.menuState.optionsOpen;
+    if (isOpen === this.menuOpen) {
+      return;
+    }
+
+    this.menuOpen = isOpen;
+    if (this.player) {
+      this.player.setInputEnabled(!this.menuOpen);
+    }
+    if (this.menuOpen) {
+      this.inputManager?.resetAll?.();
+    }
+    if (this.audio) {
+      this.audio.setDuck(this.menuOpen, 0.55, 220);
+    }
+    this.events.emit("ui-menu-state", { open: this.menuOpen });
+  }
+
+  handleUIClosePanel({ panel }) {
+    if (panel === "inventory" && this.menuState.inventoryOpen) {
+      this.menuState.inventoryOpen = false;
+      this.events.emit("ui-panel", { panel: "inventory", open: false });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    } else if (panel === "options" && this.menuState.optionsOpen) {
+      this.menuState.optionsOpen = false;
+      this.events.emit("ui-panel", { panel: "options", open: false });
+      this.handleMenuStateChanged();
+      this.syncUI(true);
+    }
+  }
+
+  handleQuickSlotAssignment({ slotIndex, itemId }) {
+    if (typeof slotIndex !== "number" || slotIndex < 0 || slotIndex >= this.quickSlots.length) {
+      return;
+    }
+    if (!itemId) {
+      this.quickSlots[slotIndex] = { index: slotIndex, itemId: null };
+      this.quickSlotsDirty = true;
+      this.markProgressDirty("quickslot");
+      this.syncUI(true);
+      return;
+    }
+    const item = this.inventory.find((entry) => entry.id === itemId);
+    if (!item) {
+      return;
+    }
+    this.quickSlots[slotIndex] = { index: slotIndex, itemId };
+    this.quickSlotsDirty = true;
+    this.markProgressDirty("quickslot");
+    this.syncUI(true);
+  }
+
+  handleRebindAction({ action, keyCode }) {
+    if (!action || typeof keyCode !== "number" || !Number.isFinite(keyCode)) {
+      return;
+    }
+    if (this.inputManager?.rebindAction(action, keyCode)) {
+      this.bindingsDirty = true;
+      this.markProgressDirty("bindings");
+      this.syncUI(true);
+    }
+  }
+
+  handleResetBindings() {
+    if (!this.inputManager) {
+      return;
+    }
+    this.inputManager.resetAllBindings();
+    this.bindingsDirty = true;
+    this.markProgressDirty("bindings");
+    this.syncUI(true);
+  }
+
+  applyOptionsPatch(patch) {
+    if (!patch) {
+      return;
+    }
+
+    this.optionsState = { ...this.optionsState, ...patch };
+    this.optionsDirty = true;
+    this.audio?.applyMixSettings(this.optionsState);
+
+    if (patch.resolutionScale !== undefined) {
+      this.updateResolutionScale();
+    }
+    if (patch.graphicsQuality !== undefined) {
+      this.applyGraphicsQuality(this.optionsState.graphicsQuality);
+    }
+
+    this.markProgressDirty("options");
+    this.syncUI(true);
+  }
+
+  updateResolutionScale() {
+    const zoom = Phaser.Math.Clamp(this.optionsState.resolutionScale ?? 1, 0.7, 1.2);
+    this.cameras.main.setZoom(zoom);
+  }
+
+  applyGraphicsQuality(quality) {
+    const engine = this.matter?.world?.engine;
+    if (!engine) {
+      return;
+    }
+    if (quality === "Performance") {
+      engine.positionIterations = 4;
+      engine.velocityIterations = 3;
+    } else {
+      engine.positionIterations = 6;
+      engine.velocityIterations = 4;
+    }
+  }
+
+  updateUIHeartbeat(delta) {
+    this.uiSyncTimer += delta;
+    if (this.uiSyncTimer < UI_SYNC_INTERVAL) {
+      return;
+    }
+    this.uiSyncTimer = 0;
+    this.syncUI();
+  }
+
+  updateSaveHeartbeat(delta) {
+    if (!this.saveManager) {
+      return;
+    }
+
+    this.autoSaveTimer += delta;
+    if (this.autoSaveTimer >= AUTO_SAVE_INTERVAL) {
+      this.autoSaveTimer = 0;
+      if (!this.saveDirty) {
+        this.markProgressDirty("autosave");
+      }
+    }
+
+    if (!this.saveDirty) {
+      return;
+    }
+
+    this.saveCooldown -= delta;
+    if (this.saveCooldown <= 0) {
+      this.commitSave();
+    }
+  }
+
+  markProgressDirty(reason = "update", immediate = false) {
+    if (this.saveDirty) {
+      this.saveCooldown = immediate ? 0 : Math.min(this.saveCooldown, SAVE_DEBOUNCE_MS);
+    } else {
+      this.saveDirty = true;
+      this.saveCooldown = immediate ? 0 : SAVE_DEBOUNCE_MS;
+    }
+    this.lastSaveReason = reason;
+    this.systemDirty = true;
+  }
+
+  commitSave() {
+    if (!this.saveManager) {
+      this.saveDirty = false;
+      return;
+    }
+
+    if (!this.saveManager.isAvailable()) {
+      this.saveDirty = false;
+      this.lastSaveStatus = { state: "disabled", timestamp: Date.now() };
+      this.systemDirty = true;
+      return;
+    }
+
+    const result = this.saveManager.save(this.collectSaveData());
+    const timestamp = result.timestamp ?? Date.now();
+    if (result.ok) {
+      this.saveDirty = false;
+      this.lastSaveStatus = { state: "success", timestamp };
+    } else if (result.reason === "unavailable") {
+      this.saveDirty = false;
+      this.lastSaveStatus = { state: "disabled", timestamp };
+    } else {
+      this.saveDirty = true;
+      this.saveCooldown = SAVE_RETRY_MS;
+      this.lastSaveStatus = { state: "error", timestamp };
+    }
+    this.systemDirty = true;
+  }
+
+  syncUI(force = false) {
+    const payload = this.buildUIState(force);
+    this.events.emit("ui-state", payload);
+    if (force || this.inventoryDirty) {
+      this.inventoryDirty = false;
+    }
+    if (force || this.quickSlotsDirty) {
+      this.quickSlotsDirty = false;
+    }
+    if (force || this.optionsDirty) {
+      this.optionsDirty = false;
+    }
+    if (force || this.bindingsDirty) {
+      this.bindingsDirty = false;
+    }
+    if (force || this.systemDirty) {
+      this.systemDirty = false;
+    }
+  }
+
+  buildUIState(force = false) {
+    const hud = this.player
+      ? {
+          hp: Math.round(this.player.stats.hp),
+          maxHp: this.player.stats.maxHP,
+          mp: Math.round(this.player.stats.mp),
+          maxMp: this.player.stats.maxMP,
+          dashCooldown: Math.max(0, Math.round(this.player.dashCooldownTimer || 0)),
+          dashReady: (this.player.dashCooldownTimer || 0) <= 0,
+          menuOpen: this.menuOpen
+        }
+      : null;
+
+    const performance = this.getPerfSnapshot();
+
+    const payload = {
+      hud,
+      performance,
+      menu: {
+        open: this.menuOpen,
+        inventoryOpen: this.menuState.inventoryOpen,
+        optionsOpen: this.menuState.optionsOpen
+      },
+      map: this.collectMapState(),
+      system: this.collectSystemState()
+    };
+
+    if (force || this.quickSlotsDirty) {
+      payload.quickSlots = this.collectQuickSlotState();
+    }
+    if (force || this.inventoryDirty) {
+      payload.inventory = this.collectInventoryState();
+    }
+    if (force || this.optionsDirty) {
+      payload.options = { ...this.optionsState };
+    }
+    if (force || this.bindingsDirty) {
+      payload.bindings = this.collectBindingState();
+    }
+
+    return payload;
+  }
+
+  collectQuickSlotState() {
+    return this.quickSlots.map((slot) => {
+      const item = slot.itemId ? this.inventory.find((entry) => entry.id === slot.itemId) : null;
+      return {
+        index: slot.index,
+        itemId: slot.itemId,
+        name: item?.name ?? null,
+        quantity: item?.quantity ?? 0
+      };
+    });
+  }
+
+  collectInventoryState() {
+    return this.inventory.map((item) => ({ ...item }));
+  }
+
+  collectBindingState() {
+    if (!this.inputManager?.getBindingSnapshot) {
+      return [];
+    }
+    return this.inputManager.getBindingSnapshot();
+  }
+
+  collectSaveData() {
+    const payload = {
+      inventory: this.collectInventoryState(),
+      quickSlots: this.quickSlots.map((slot) => ({
+        index: slot.index,
+        itemId: slot.itemId ?? null
+      })),
+      options: { ...this.optionsState },
+      bindings: this.inputManager?.getBindingSnapshot
+        ? this.inputManager.getBindingSnapshot().map((entry) => ({
+            action: entry.action,
+            codes: Array.isArray(entry.codes) ? [...entry.codes] : []
+          }))
+        : []
+    };
+
+    if (this.player) {
+      payload.player = {
+        x: Math.round(this.player.x),
+        y: Math.round(this.player.y),
+        hp: Math.round(this.player.stats.hp),
+        mp: Math.round(this.player.stats.mp)
+      };
+    }
+
+    return payload;
+  }
+
+  countActiveProjectiles() {
+    let count = 0;
+    this.projectiles.forEach((projectile) => {
+      if (projectile.active) {
+        count += 1;
+      }
+    });
+    return count;
+  }
+
+  getPerfSnapshot() {
+    const objects = this.children?.list?.length ?? 0;
+    const mobsActive = this.mobSpawner ? this.mobSpawner.getManagedCount() : 0;
+    const mobsVisible = this.mobSpawner ? this.mobSpawner.getVisibleCount() : 0;
+    const projectileCount = this.countActiveProjectiles();
+
+    return {
+      fps: this.game.loop.actualFps || 0,
+      frameTime: this.lastFrameTime,
+      objects,
+      mobsActive,
+      mobsVisible,
+      projectiles: projectileCount,
+      pools: {
+        projectile: this.projectilePool
+          ? { live: this.projectilePool.getLiveCount(), free: this.projectilePool.getFreeCount() }
+          : null,
+        damageText: this.damageTextPool
+          ? { live: this.damageTextPool.getLiveCount(), free: this.damageTextPool.getFreeCount() }
+          : null
+      }
+    };
+  }
+
+  collectSystemState() {
+    return {
+      save: {
+        state: this.lastSaveStatus?.state ?? "idle",
+        timestamp: this.lastSaveStatus?.timestamp ?? 0,
+        dirty: this.saveDirty,
+        reason: this.lastSaveReason,
+        available: this.saveManager?.isAvailable() ?? false
+      }
+    };
+  }
+
+  collectMapState() {
+    if (!this.map) {
+      return null;
+    }
+    const mobs = [];
+    if (this.mobSpawner) {
+      this.mobSpawner.getActiveMobs().forEach((mob) => {
+        if (mob.active && !mob.isCulled) {
+          mobs.push({ x: mob.x, y: mob.y });
+        }
+      });
+    }
+    const view = this.cameras.main.worldView;
+    return {
+      width: this.map.widthInPixels,
+      height: this.map.heightInPixels,
+      player: this.player ? { x: this.player.x, y: this.player.y } : null,
+      camera: { x: view.x, y: view.y, width: view.width, height: view.height },
+      mobs
+    };
   }
 
   handleCombatInput() {
-    if (!this.inputManager || !this.player) {
+    if (!this.inputManager || !this.player || this.menuOpen) {
       return;
     }
 
@@ -249,8 +878,18 @@ export default class GameScene extends Phaser.Scene {
       return;
     }
     const mobs = this.mobSpawner.getActiveMobs();
+    const camera = this.cameras?.main;
+    const view = camera ? camera.worldView : null;
+    const left = view ? view.x - PROJECTILE_CULL_PADDING : Number.NEGATIVE_INFINITY;
+    const right = view ? view.right + PROJECTILE_CULL_PADDING : Number.POSITIVE_INFINITY;
+    const top = view ? view.y - PROJECTILE_CULL_PADDING : Number.NEGATIVE_INFINITY;
+    const bottom = view ? view.bottom + PROJECTILE_CULL_PADDING : Number.POSITIVE_INFINITY;
     this.projectiles.forEach((projectile) => {
       if (!projectile.active) {
+        return;
+      }
+      if (projectile.x < left || projectile.x > right || projectile.y < top || projectile.y > bottom) {
+        projectile.lifespan = 0;
         return;
       }
       const bounds = projectile.getBounds();
@@ -283,6 +922,7 @@ export default class GameScene extends Phaser.Scene {
           mob.pendingHit = false;
           this.cameras.main.flash(80, 255, 80, 80);
           this.audio?.play(ASSET_KEYS.AUDIO.CORE_SFX, "hit");
+          this.markProgressDirty("player-damage");
         }
       }
     });
@@ -301,73 +941,90 @@ export default class GameScene extends Phaser.Scene {
     });
   }
 
-  updateHud() {
-    if (!this.debugHud || !this.player || !this.player.body) {
+  spawnDamageNumber(x, y, value, color) {
+    if (!this.damageTextPool) {
       return;
     }
-    const velocity = this.player.body.velocity;
-    const speedX = Math.round(velocity.x * 60);
-    const speedY = Math.round(velocity.y * 60);
-    const posX = Math.round(this.player.x);
-    const posY = Math.round(this.player.y);
-    const mobs = this.mobSpawner ? this.mobSpawner.getActiveMobs().length : 0;
-    const hp = this.player.stats.hp;       // 현재 체력
-    const maxHp = this.player.stats.maxHP; // 최대 체력
+    const tint = color ?? "#ff5e5e";
+    const text = this.damageTextPool.obtain();
+    text.setText(String(value));
+    text.setColor(tint);
+    text.setPosition(x, y);
+    text.setAlpha(1);
+    text.setScale(1);
+    text.setActive(true);
+    text.setVisible(true);
+    this.tweens.killTweensOf(text);
 
-    this.debugHud.setText([
-     "Player",
-     `HP ${hp} / ${maxHp}`,
-      `X ${Math.round(this.player.body.velocity.x * 60)} px/s`,
-     `Y ${Math.round(this.player.body.velocity.y * 60)} px/s`,
-     `Pos ${Math.round(this.player.x)}, ${Math.round(this.player.y)}`,
-     `Ground ${this.player.isOnGround}`,
-     `Dash ${this.player.isDashing}`,
-     `Mobs ${this.mobSpawner ? this.mobSpawner.activeMobs.size : 0}`
-    ]);
-  }
-  spawnDamageNumber(x, y, value, color) 
-  {
-  if (color === undefined || color === null) color = "#ff5e5e";
-
-  const text = this.add.text(x, y, String(value), {
-    fontFamily: "Rubik, 'Segoe UI', sans-serif",
-    fontSize: "18px",
-    color
-  });
-  text.setDepth(80);
-  text.setOrigin(0.5, 1);
-
-  this.tweens.add({
-    targets: text,
-    y: y - 32,
-    alpha: 0,
-    duration: 400,
-    ease: "Cubic.Out",
-    onComplete: () => text.destroy()
-  });
+    this.tweens.add({
+      targets: text,
+      y: y - 32,
+      alpha: 0,
+      duration: 400,
+      ease: "Cubic.Out",
+      onComplete: () => {
+        this.damageTextPool.release(text);
+      }
+    });
   }
 
-
-  spawnLoot(x, y) 
-  {
-    const loot = this.add.rectangle(x, y, 12, 12, 0xffd166);
-    loot.setDepth(70);
+  spawnLoot(x, y) {
+    if (!this.lootPool) {
+      return;
+    }
+    const loot = this.lootPool.obtain();
+    loot.setPosition(x, y);
+    loot.setAlpha(1);
+    loot.setScale(1);
+    loot.setActive(true);
+    loot.setVisible(true);
+    this.tweens.killTweensOf(loot);
     this.tweens.add({
       targets: loot,
       y: y + 24,
       alpha: 0,
       duration: 600,
       ease: "Sine.In",
-      onComplete: () => loot.destroy()
+      onComplete: () => {
+        this.lootPool.release(loot);
+      }
     });
   }
 
   shutdown() {
+    if (this.saveManager) {
+      this.saveDirty = true;
+      this.commitSave();
+    }
+    this.audio?.stopBgm({ fadeOut: 160 });
     this.perfMeter?.destroy();
     this.perfMeter = null;
     this.player = null;
     this.layers = {};
     this.parallaxLayers = [];
     this.inputManager = null;
+    this.projectiles.clear();
+    if (this.damageTextPool) {
+      this.damageTextPool.forEachLive((text) => text.destroy());
+      this.damageTextPool.free.forEach((text) => text.destroy());
+      this.damageTextPool = null;
+    }
+    if (this.lootPool) {
+      this.lootPool.forEachLive((rect) => rect.destroy());
+      this.lootPool.free.forEach((rect) => rect.destroy());
+      this.lootPool = null;
+    }
+    if (this.scene.isActive && this.scene.isActive("UIScene")) {
+      this.scene.stop("UIScene");
+    }
+    this.events.off("ui-options-change", this.applyOptionsPatch, this);
+    this.events.off("ui-assign-quick-slot", this.handleQuickSlotAssignment, this);
+    this.events.off("ui-close-panel", this.handleUIClosePanel, this);
+    this.events.off("ui-rebind-action", this.handleRebindAction, this);
+    this.events.off("ui-reset-bindings", this.handleResetBindings, this);
+    this.events.off("ui-ready", this.handleUIReady, this);
+    this.audio = null;
+    this.saveManager = null;
+    this.restoredData = null;
   }
 }

--- a/phaser-vertical-slice/src/scenes/UIScene.js
+++ b/phaser-vertical-slice/src/scenes/UIScene.js
@@ -1,0 +1,1140 @@
+import Phaser from "../phaser.js";
+import { INPUT_KEYS } from "../systems/InputManager.js";
+
+const HUD_DEPTH = 2000;
+const QUICK_SLOT_COUNT = 4;
+const MINI_MAP_SIZE = { width: 176, height: 112 };
+const OPTIONS_VISIBLE_COUNT = 9;
+
+export default class UIScene extends Phaser.Scene {
+  constructor() {
+    super({ key: "UIScene" });
+    this.gameSceneKey = "GameScene";
+    this.gameScene = null;
+    this.hud = null;
+    this.hpBarWidth = 220;
+    this.mpBarWidth = 220;
+    this.performanceText = null;
+    this.quickSlotContainer = null;
+    this.quickSlotVisuals = [];
+    this.miniMapContainer = null;
+    this.miniMapGraphics = null;
+    this.inventoryContainer = null;
+    this.inventoryListText = null;
+    this.inventoryDetailText = null;
+    this.inventoryHintText = null;
+    this.inventoryData = [];
+    this.inventoryVisible = false;
+    this.inventorySelectionIndex = 0;
+    this.quickSlotData = [];
+    this.optionsContainer = null;
+    this.optionsListText = null;
+    this.optionsHintText = null;
+    this.optionsState = {};
+    this.optionsConfig = this.createOptionsConfig();
+    this.optionsVisible = false;
+    this.optionsSelectionIndex = 0;
+    this.optionsScrollOffset = 0;
+    this.navKeys = null;
+    this.bindingState = [];
+    this.bindingLookup = new Map();
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    this.optionsHintBase = "";
+    this.systemStatusText = null;
+    this.systemState = { save: { state: "idle", timestamp: 0, dirty: false, reason: "", available: true } };
+    this.bugOverlay = null;
+    this.bugOverlayText = null;
+    this.bugOverlayVisible = false;
+    this.bugToggleKey = null;
+  }
+
+  init(data) {
+    const providedKey = data && typeof data.gameSceneKey === "string" ? data.gameSceneKey : null;
+    this.gameSceneKey = providedKey || "GameScene";
+  }
+
+  create() {
+    this.gameScene = this.scene.get(this.gameSceneKey);
+    if (!this.gameScene) {
+      this.gameScene = this.scene.get("GameScene");
+    }
+
+    this.createHud();
+    this.createPerformanceReadout();
+    this.createQuickSlots();
+    this.createMiniMap();
+    this.createInventoryPanel();
+    this.createOptionsPanel();
+    this.createSystemBanner();
+    this.createBugOverlay();
+    this.installInputHandlers();
+
+    this.scene.bringToTop();
+    this.bindGameSceneEvents();
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.shutdown, this);
+
+    this.emitGameEvent("ui-ready");
+  }
+
+  bindGameSceneEvents() {
+    if (!this.gameScene || !this.gameScene.events) {
+      return;
+    }
+    this.gameScene.events.on("ui-state", this.handleStateUpdate, this);
+    this.gameScene.events.on("ui-panel", this.handlePanelToggle, this);
+    this.gameScene.events.on("ui-menu-state", this.handleMenuState, this);
+  }
+
+  emitGameEvent(eventName, payload) {
+    if (this.gameScene && this.gameScene.events) {
+      this.gameScene.events.emit(eventName, payload);
+    }
+  }
+
+  createHud() {
+    const container = this.add.container(24, 24).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 260, 96, 0x121625, 0.82)
+      .setOrigin(0, 0)
+      .setStrokeStyle(2, 0x2d314a, 0.85);
+    container.add(bg);
+
+    const hpLabel = this.add.text(16, 12, "HP", this.getLabelStyle());
+    container.add(hpLabel);
+    const hpBg = this.add
+      .rectangle(16, 36, this.hpBarWidth, 18, 0x1b2133, 0.92)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(1, 0xff849d, 0.8);
+    container.add(hpBg);
+    const hpFill = this.add.rectangle(16, 36, this.hpBarWidth, 14, 0xff5d6c).setOrigin(0, 0.5);
+    container.add(hpFill);
+    const hpText = this.add.text(16 + this.hpBarWidth + 12, 36, "0 / 0", this.getValueStyle()).setOrigin(0, 0.5);
+    container.add(hpText);
+
+    const mpLabel = this.add.text(16, 60, "MP", this.getLabelStyle());
+    container.add(mpLabel);
+    const mpBg = this.add
+      .rectangle(16, 82, this.mpBarWidth, 18, 0x171d2c, 0.92)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(1, 0x6bb0ff, 0.8);
+    container.add(mpBg);
+    const mpFill = this.add.rectangle(16, 82, this.mpBarWidth, 14, 0x5aa6ff).setOrigin(0, 0.5);
+    container.add(mpFill);
+    const mpText = this.add.text(16 + this.mpBarWidth + 12, 82, "0 / 0", this.getValueStyle()).setOrigin(0, 0.5);
+    container.add(mpText);
+
+    const dashText = this.add.text(16, 108, "Dash Ready", this.getHintStyle());
+    dashText.setAlpha(0.9);
+    container.add(dashText);
+
+    this.hud = {
+      container,
+      hpFill,
+      hpText,
+      mpFill,
+      mpText,
+      dashText
+    };
+  }
+
+  createPerformanceReadout() {
+    this.performanceText = this.add
+      .text(24, this.scale.height - 140, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "16px",
+        color: "#d3d7ff"
+      })
+      .setDepth(HUD_DEPTH)
+      .setScrollFactor(0);
+  }
+
+  createQuickSlots() {
+    const container = this.add.container(this.scale.width * 0.5, this.scale.height - 72).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 320, 68, 0x121625, 0.78)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x313855, 0.85);
+    container.add(bg);
+
+    const spacing = 72;
+    const offset = -((QUICK_SLOT_COUNT - 1) * spacing) / 2;
+    for (let i = 0; i < QUICK_SLOT_COUNT; i += 1) {
+      const slotX = offset + i * spacing;
+      const frame = this.add
+        .rectangle(slotX, 0, 52, 52, 0x1b2235, 0.9)
+        .setOrigin(0.5)
+        .setStrokeStyle(1, 0x4d5a7d, 0.9);
+      const label = this.add
+        .text(slotX, -8, "--", {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "16px",
+          color: "#f4f5ff"
+        })
+        .setOrigin(0.5);
+      const quantity = this.add
+        .text(slotX, 14, "", {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "14px",
+          color: "#9ba6d1"
+        })
+        .setOrigin(0.5);
+      const hotkey = this.add
+        .text(slotX, 24, `${i + 1}`, {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "12px",
+          color: "#94a0c8"
+        })
+        .setOrigin(0.5);
+
+      container.add(frame);
+      container.add(label);
+      container.add(quantity);
+      container.add(hotkey);
+
+      this.quickSlotVisuals.push({ frame, label, quantity, hotkey });
+    }
+
+    this.quickSlotContainer = container;
+  }
+
+  createMiniMap() {
+    const container = this.add.container(this.scale.width - 220, 20).setDepth(HUD_DEPTH).setScrollFactor(0);
+    const bg = this.add
+      .rectangle(0, 0, 200, 156, 0x111523, 0.86)
+      .setOrigin(0, 0)
+      .setStrokeStyle(2, 0x2d3955, 0.85);
+    const title = this.add.text(12, 10, "Mini-Map", this.getLabelStyle());
+    const mapFrame = this.add
+      .rectangle(12, 34, MINI_MAP_SIZE.width, MINI_MAP_SIZE.height, 0x0c101c, 0.92)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, 0x36446b, 0.8);
+    const graphics = this.add.graphics().setPosition(12, 34).setDepth(HUD_DEPTH + 1).setScrollFactor(0);
+
+    container.add([bg, title, mapFrame, graphics]);
+
+    this.miniMapContainer = container;
+    this.miniMapGraphics = graphics;
+  }
+
+  createInventoryPanel() {
+    const container = this.add
+      .container(this.scale.width * 0.5, this.scale.height * 0.5)
+      .setDepth(HUD_DEPTH + 10)
+      .setScrollFactor(0)
+      .setVisible(false);
+
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.55).setOrigin(0.5).setInteractive();
+    const panel = this.add
+      .rectangle(0, 0, 520, 360, 0x111522, 0.95)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x3a476a, 0.85);
+    const title = this.add.text(-220, -150, "Inventory", this.getTitleStyle());
+    const list = this.add
+      .text(-220, -110, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "18px",
+        color: "#f2f4ff",
+        lineSpacing: 6
+      })
+      .setOrigin(0, 0);
+    const detail = this.add
+      .text(-220, 40, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "16px",
+        color: "#d0d7ff",
+        wordWrap: { width: 480 }
+      })
+      .setOrigin(0, 0);
+    const hint = this.add
+      .text(
+        -220,
+        140,
+        "\u2191\u2193 \uc120\ud0dd \u2022 1~4 \ud035\uc2ac\ub86f \uc9c0\uc815 \u2022 ESC \ub2eb\uae30",
+        this.getHintStyle()
+      )
+      .setOrigin(0, 0);
+
+    overlay.on("pointerdown", () => {
+      this.emitGameEvent("ui-close-panel", { panel: "inventory" });
+    });
+
+    container.add([overlay, panel, title, list, detail, hint]);
+
+    this.inventoryContainer = container;
+    this.inventoryListText = list;
+    this.inventoryDetailText = detail;
+    this.inventoryHintText = hint;
+  }
+
+  createOptionsPanel() {
+    const container = this.add
+      .container(this.scale.width * 0.5, this.scale.height * 0.5)
+      .setDepth(HUD_DEPTH + 12)
+      .setScrollFactor(0)
+      .setVisible(false);
+
+    const overlay = this.add.rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.55).setOrigin(0.5).setInteractive();
+    const panel = this.add
+      .rectangle(0, 0, 460, 320, 0x111522, 0.95)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x2f4163, 0.85);
+    const title = this.add.text(-200, -130, "Options", this.getTitleStyle());
+    const list = this.add
+      .text(-200, -90, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "16px",
+        color: "#f2f4ff",
+        lineSpacing: 6
+      })
+      .setOrigin(0, 0);
+    const baseHint =
+      "\u2191\u2193 \ud56d\ubaa9 \uc774\ub3d9 \u2022 \u2190\u2192 \uac12 \uc870\uc815 \u2022 Enter \ud0a4 \uc7ac\uc124\uc815 \u2022 ESC \ub2eb\uae30";
+    const hint = this.add.text(-200, 120, baseHint, this.getHintStyle()).setOrigin(0, 0);
+
+    overlay.on("pointerdown", () => {
+      this.emitGameEvent("ui-close-panel", { panel: "options" });
+    });
+
+    container.add([overlay, panel, title, list, hint]);
+
+    this.optionsContainer = container;
+    this.optionsListText = list;
+    this.optionsHintText = hint;
+    this.optionsHintBase = baseHint;
+  }
+
+  createSystemBanner() {
+    this.systemStatusText = this.add
+      .text(24, this.scale.height - 92, "", {
+        fontFamily: "Rubik, 'Segoe UI', sans-serif",
+        fontSize: "14px",
+        color: "#d3d7ff"
+      })
+      .setDepth(HUD_DEPTH)
+      .setScrollFactor(0);
+  }
+
+  createBugOverlay() {
+    const container = this.add
+      .container(this.scale.width * 0.5, this.scale.height * 0.5)
+      .setDepth(HUD_DEPTH + 60)
+      .setScrollFactor(0)
+      .setVisible(false);
+
+    const overlay = this.add
+      .rectangle(0, 0, this.scale.width, this.scale.height, 0x000000, 0.68)
+      .setOrigin(0.5)
+      .setInteractive();
+
+    const panelWidth = Math.min(620, this.scale.width - 80);
+    const panelHeight = Math.min(360, this.scale.height - 80);
+    const panel = this.add
+      .rectangle(0, 0, panelWidth, panelHeight, 0x111522, 0.95)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0x3a476a, 0.85);
+
+    const title = this.add.text(0, -panelHeight * 0.5 + 28, "Bug Report Checklist", this.getTitleStyle()).setOrigin(0.5, 0);
+
+    const body = this.add
+      .text(
+        -panelWidth * 0.5 + 24,
+        -panelHeight * 0.5 + 72,
+        "",
+        {
+          fontFamily: "Rubik, 'Segoe UI', sans-serif",
+          fontSize: "16px",
+          color: "#f2f4ff",
+          lineSpacing: 6,
+          wordWrap: { width: panelWidth - 48 }
+        }
+      )
+      .setOrigin(0, 0);
+
+    overlay.on("pointerdown", () => {
+      this.toggleBugOverlay(false);
+    });
+
+    container.add([overlay, panel, title, body]);
+
+    this.bugOverlay = container;
+    this.bugOverlayText = body;
+  }
+
+  installInputHandlers() {
+    this.navKeys = this.input.keyboard.addKeys({
+      up: Phaser.Input.Keyboard.KeyCodes.UP,
+      down: Phaser.Input.Keyboard.KeyCodes.DOWN,
+      left: Phaser.Input.Keyboard.KeyCodes.LEFT,
+      right: Phaser.Input.Keyboard.KeyCodes.RIGHT,
+      esc: Phaser.Input.Keyboard.KeyCodes.ESC,
+      enter: Phaser.Input.Keyboard.KeyCodes.ENTER,
+      one: Phaser.Input.Keyboard.KeyCodes.ONE,
+      two: Phaser.Input.Keyboard.KeyCodes.TWO,
+      three: Phaser.Input.Keyboard.KeyCodes.THREE,
+      four: Phaser.Input.Keyboard.KeyCodes.FOUR
+    });
+    this.input.keyboard.on("keydown", this.handleGlobalKeydown, this);
+    this.input.keyboard.on("keydown-ESC", this.handleEscKey, this);
+    this.bugToggleKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.F8);
+    if (this.bugToggleKey) {
+      this.bugToggleKey.on("down", () => {
+        this.toggleBugOverlay();
+      });
+    }
+  }
+
+  update() {
+    if (this.inventoryVisible) {
+      this.handleInventoryInput();
+    }
+    if (this.optionsVisible) {
+      this.handleOptionsInput();
+    }
+  }
+
+  handleStateUpdate(payload) {
+    if (!payload) {
+      return;
+    }
+
+    if (payload.hud) {
+      this.updateHud(payload.hud);
+    }
+    if (payload.performance) {
+      this.updatePerformance(payload.performance);
+    }
+    if (payload.quickSlots) {
+      this.quickSlotData = payload.quickSlots;
+      this.updateQuickSlots();
+    }
+    if (payload.inventory) {
+      this.inventoryData = payload.inventory;
+      if (this.inventoryVisible) {
+        this.refreshInventoryList();
+      }
+    }
+    if (payload.options) {
+      this.optionsState = { ...this.optionsState, ...payload.options };
+      if (this.optionsVisible) {
+        this.refreshOptionsList();
+      }
+    }
+    if (payload.bindings) {
+      this.setBindingState(payload.bindings);
+    }
+    if (payload.map) {
+      this.updateMiniMap(payload.map);
+    }
+    if (payload.menu) {
+      this.handleMenuState(payload.menu);
+      this.syncPanelsFromMenu(payload.menu);
+    }
+    if (payload.system) {
+      this.updateSystemStatus(payload.system);
+    }
+  }
+
+  syncPanelsFromMenu(menuState) {
+    if (!menuState) {
+      return;
+    }
+
+    if (menuState.inventoryOpen !== undefined && this.inventoryContainer) {
+      const shouldOpen = Boolean(menuState.inventoryOpen);
+      if (this.inventoryVisible !== shouldOpen) {
+        this.inventoryVisible = shouldOpen;
+        this.inventoryContainer.setVisible(shouldOpen);
+        if (shouldOpen) {
+          this.inventorySelectionIndex = Phaser.Math.Clamp(
+            this.inventorySelectionIndex,
+            0,
+            Math.max(0, this.inventoryData.length - 1)
+          );
+          this.refreshInventoryList();
+        }
+      }
+    }
+
+    if (menuState.optionsOpen !== undefined && this.optionsContainer) {
+      const shouldOpen = Boolean(menuState.optionsOpen);
+      if (this.optionsVisible !== shouldOpen) {
+        this.optionsVisible = shouldOpen;
+        this.optionsContainer.setVisible(shouldOpen);
+        if (shouldOpen) {
+          this.refreshOptionsList();
+        } else {
+          this.cancelBindingCapture();
+        }
+      }
+    }
+  }
+
+  handlePanelToggle({ panel, open }) {
+    if (panel === "inventory") {
+      this.inventoryVisible = open;
+      this.inventoryContainer.setVisible(open);
+      if (open) {
+        this.inventorySelectionIndex = Phaser.Math.Clamp(this.inventorySelectionIndex, 0, Math.max(0, this.inventoryData.length - 1));
+        this.refreshInventoryList();
+      }
+    } else if (panel === "options") {
+      this.optionsVisible = open;
+      this.optionsContainer.setVisible(open);
+      if (open) {
+        this.refreshOptionsList();
+      } else {
+        this.cancelBindingCapture();
+      }
+    }
+  }
+
+  handleMenuState({ open }) {
+    const alpha = open ? 0.45 : 1;
+    if (this.hud) {
+      this.hud.container.setAlpha(alpha);
+    }
+    if (this.quickSlotContainer) {
+      this.quickSlotContainer.setAlpha(open ? 0.6 : 1);
+    }
+  }
+
+  handleEscKey() {
+    if (this.bindingListenAction) {
+      return;
+    }
+    if (this.bugOverlayVisible) {
+      this.toggleBugOverlay(false);
+    }
+  }
+
+  toggleBugOverlay(force) {
+    if (!this.bugOverlay) {
+      return;
+    }
+    const target = typeof force === "boolean" ? force : !this.bugOverlayVisible;
+    this.bugOverlayVisible = target;
+    this.bugOverlay.setVisible(target);
+    if (target) {
+      this.refreshBugOverlay();
+    }
+  }
+
+  refreshBugOverlay() {
+    if (!this.bugOverlayText) {
+      return;
+    }
+    const save = this.systemState?.save || {};
+    const statusLine = (() => {
+      if (!save.available) {
+        return "⚠ 저장 불가: 브라우저 저장소 접근 차단";
+      }
+      if (save.state === "error") {
+        return "⚠ 저장 실패: 콘솔 오류와 재현 절차를 첨부하세요";
+      }
+      if (save.state === "success") {
+        return `마지막 저장: ${this.formatTimestamp(save.timestamp)}`;
+      }
+      if (save.dirty) {
+        return "저장 대기 중 (잠시 후 자동 저장)";
+      }
+      return "저장 상태: 대기 중";
+    })();
+
+    const lines = [
+      statusLine,
+      "",
+      "• 증상이 발생한 입력/행동 순서를 단계별로 적어주세요.",
+      "• 브라우저, 운영체제, FPS(좌측 상단)을 기록하세요.",
+      "• 개발자 도구 콘솔 오류와 화면 스크린샷을 첨부하면 빠르게 재현할 수 있습니다.",
+      "• F8로 이 패널을 열고 ESC로 닫습니다."
+    ];
+
+    this.bugOverlayText.setText(lines.join("\n"));
+  }
+
+  updateSystemStatus(system) {
+    if (!system) {
+      return;
+    }
+    const mergedSave = { ...this.systemState.save, ...(system.save || {}) };
+    this.systemState = { ...this.systemState, ...system, save: mergedSave };
+
+    if (this.systemStatusText) {
+      let message = "자동 저장 대기 중";
+      let color = "#d3d7ff";
+      if (!mergedSave.available) {
+        message = "⚠ 저장 불가: 브라우저 저장소 차단";
+        color = "#ff9176";
+      } else if (mergedSave.state === "error") {
+        message = "⚠ 저장 실패: 콘솔 로그 확인";
+        color = "#ff9176";
+      } else if (mergedSave.state === "success" && mergedSave.timestamp) {
+        message = `저장 완료 ${this.formatTimestamp(mergedSave.timestamp)}`;
+      } else if (mergedSave.dirty) {
+        message = "저장 대기 중...";
+      }
+      const infoLines = [message, "F8: 버그 리포트 패널"];
+      this.systemStatusText.setText(infoLines);
+      this.systemStatusText.setColor(color);
+    }
+
+    if (this.bugOverlayVisible) {
+      this.refreshBugOverlay();
+    }
+  }
+
+  formatTimestamp(timestamp) {
+    if (typeof timestamp !== "number" || Number.isNaN(timestamp) || timestamp <= 0) {
+      return "--:--:--";
+    }
+    try {
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) {
+        return "--:--:--";
+      }
+      return date.toLocaleTimeString("ko-KR", { hour12: false });
+    } catch (error) {
+      return "--:--:--";
+    }
+  }
+
+  setBindingState(bindings) {
+    if (!Array.isArray(bindings)) {
+      this.bindingState = [];
+      this.bindingLookup = new Map();
+      return;
+    }
+    this.bindingState = bindings;
+    this.bindingLookup = new Map();
+    bindings.forEach((entry) => {
+      if (entry && entry.action) {
+        this.bindingLookup.set(entry.action, entry);
+      }
+    });
+    if (this.optionsVisible) {
+      this.refreshOptionsList();
+    }
+  }
+
+  updateHud(hudState) {
+    const hpRatio = hudState.maxHp > 0 ? Phaser.Math.Clamp(hudState.hp / hudState.maxHp, 0, 1) : 0;
+    const mpRatio = hudState.maxMp > 0 ? Phaser.Math.Clamp(hudState.mp / hudState.maxMp, 0, 1) : 0;
+
+    this.hud.hpFill.displayWidth = this.hpBarWidth * hpRatio;
+    this.hud.hpText.setText(`${hudState.hp} / ${hudState.maxHp}`);
+    this.hud.mpFill.displayWidth = this.mpBarWidth * mpRatio;
+    this.hud.mpText.setText(`${hudState.mp} / ${hudState.maxMp}`);
+    this.hud.dashText.setText(hudState.dashReady ? "Dash Ready" : `Dash Cooldown ${Math.ceil(hudState.dashCooldown / 60)}f`);
+  }
+
+  updatePerformance(performance) {
+    const fps = performance && typeof performance.fps === "number" ? performance.fps : 0;
+    const frameTime = performance && typeof performance.frameTime === "number" ? performance.frameTime : 0;
+    const objects = performance && typeof performance.objects === "number" ? performance.objects : 0;
+    const mobsVisible =
+      performance && typeof performance.mobsVisible === "number"
+        ? performance.mobsVisible
+        : performance && typeof performance.mobs === "number"
+          ? performance.mobs
+          : 0;
+    const mobsActive =
+      performance && typeof performance.mobsActive === "number" ? performance.mobsActive : mobsVisible;
+    const projectiles =
+      performance && typeof performance.projectiles === "number" ? performance.projectiles : 0;
+    const projectilePool = performance?.pools?.projectile;
+    const textPool = performance?.pools?.damageText;
+    const lines = [
+      `FPS ${fps.toFixed(0)}`,
+      `Frame ${frameTime.toFixed(1)} ms`,
+      `Objects ${objects}`,
+      `Mobs ${mobsVisible}/${mobsActive}`,
+      `Projectiles ${projectiles}`
+    ];
+    if (projectilePool) {
+      const live = typeof projectilePool.live === "number" ? projectilePool.live : 0;
+      const free = typeof projectilePool.free === "number" ? projectilePool.free : 0;
+      lines.push(`ProjPool ${live}/${free}`);
+    }
+    if (textPool) {
+      const live = typeof textPool.live === "number" ? textPool.live : 0;
+      const free = typeof textPool.free === "number" ? textPool.free : 0;
+      lines.push(`TextPool ${live}/${free}`);
+    }
+    this.performanceText.setText(lines);
+  }
+
+  updateQuickSlots() {
+    this.quickSlotVisuals.forEach((visual) => {
+      visual.frame.setFillStyle(0x151b2a, 0.8);
+      visual.label.setText("--");
+      visual.quantity.setText("");
+    });
+
+    this.quickSlotData.forEach((slot, index) => {
+      const visual = this.quickSlotVisuals[index];
+      if (!visual || !slot || !slot.itemId) {
+        return;
+      }
+      visual.frame.setFillStyle(0x1f273a, 0.9);
+      const name = slot.name || "--";
+      visual.label.setText(name.length > 9 ? `${name.slice(0, 8)}...` : name);
+      visual.quantity.setText(slot.quantity > 1 ? `x${slot.quantity}` : "");
+    });
+  }
+
+  updateMiniMap(mapState) {
+    const graphics = this.miniMapGraphics;
+    if (!graphics) {
+      return;
+    }
+
+    graphics.clear();
+    graphics.fillStyle(0x0f1423, 0.9);
+    graphics.fillRect(0, 0, MINI_MAP_SIZE.width, MINI_MAP_SIZE.height);
+
+    if (!mapState || !mapState.width || !mapState.height) {
+      return;
+    }
+
+    const scale = Math.min(MINI_MAP_SIZE.width / mapState.width, MINI_MAP_SIZE.height / mapState.height);
+    const offsetX = (MINI_MAP_SIZE.width - mapState.width * scale) * 0.5;
+    const offsetY = (MINI_MAP_SIZE.height - mapState.height * scale) * 0.5;
+
+    function drawPoint(color, x, y, size) {
+      const pointSize = typeof size === "number" ? size : 4;
+      graphics.fillStyle(color, 1);
+      graphics.fillRect(
+        offsetX + x * scale - pointSize * 0.5,
+        offsetY + y * scale - pointSize * 0.5,
+        pointSize,
+        pointSize
+      );
+    }
+
+    if (mapState.player) {
+      drawPoint(0x6cf1ff, mapState.player.x, mapState.player.y, 6);
+    }
+    if (Array.isArray(mapState.mobs)) {
+      for (let i = 0; i < mapState.mobs.length; i += 1) {
+        const mob = mapState.mobs[i];
+        if (mob) {
+          drawPoint(0xff915d, mob.x, mob.y, 4);
+        }
+      }
+    }
+
+    if (mapState.camera) {
+      graphics.lineStyle(1, 0xffffff, 0.7);
+      graphics.strokeRect(
+        offsetX + mapState.camera.x * scale,
+        offsetY + mapState.camera.y * scale,
+        mapState.camera.width * scale,
+        mapState.camera.height * scale
+      );
+    }
+  }
+
+  handleInventoryInput() {
+    const hasItems = this.inventoryData.length > 0;
+
+    if (hasItems) {
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.up)) {
+        this.inventorySelectionIndex = Phaser.Math.Wrap(
+          this.inventorySelectionIndex - 1,
+          0,
+          Math.max(1, this.inventoryData.length)
+        );
+        this.refreshInventoryList();
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.down)) {
+        this.inventorySelectionIndex = Phaser.Math.Wrap(
+          this.inventorySelectionIndex + 1,
+          0,
+          Math.max(1, this.inventoryData.length)
+        );
+        this.refreshInventoryList();
+      }
+
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.one)) {
+        this.assignQuickSlot(0);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.two)) {
+        this.assignQuickSlot(1);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.three)) {
+        this.assignQuickSlot(2);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.four)) {
+        this.assignQuickSlot(3);
+      }
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.esc)) {
+      this.emitGameEvent("ui-close-panel", { panel: "inventory" });
+    }
+  }
+
+  handleOptionsInput() {
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.esc)) {
+      if (this.bindingListenAction) {
+        this.cancelBindingCapture();
+      } else {
+        this.emitGameEvent("ui-close-panel", { panel: "options" });
+      }
+      return;
+    }
+
+    if (this.bindingListenAction) {
+      return;
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.navKeys.up)) {
+      this.optionsSelectionIndex = Phaser.Math.Wrap(this.optionsSelectionIndex - 1, 0, this.optionsConfig.length);
+      this.refreshOptionsList();
+    } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.down)) {
+      this.optionsSelectionIndex = Phaser.Math.Wrap(this.optionsSelectionIndex + 1, 0, this.optionsConfig.length);
+      this.refreshOptionsList();
+    }
+
+    const config = this.optionsConfig[this.optionsSelectionIndex];
+    if (!config) {
+      return;
+    }
+
+    if (config.type === "range" || config.type === "choice") {
+      if (Phaser.Input.Keyboard.JustDown(this.navKeys.left)) {
+        this.modifyOption(-1);
+      } else if (Phaser.Input.Keyboard.JustDown(this.navKeys.right)) {
+        this.modifyOption(1);
+      }
+    } else if (config.type === "binding") {
+      if (
+        Phaser.Input.Keyboard.JustDown(this.navKeys.left) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.right) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.enter)
+      ) {
+        this.beginBindingCapture(config);
+      }
+    } else if (config.type === "action") {
+      if (
+        Phaser.Input.Keyboard.JustDown(this.navKeys.left) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.right) ||
+        Phaser.Input.Keyboard.JustDown(this.navKeys.enter)
+      ) {
+        this.triggerOptionAction(config);
+      }
+    }
+  }
+
+  assignQuickSlot(slotIndex) {
+    if (!this.inventoryData.length) {
+      return;
+    }
+    const item = this.inventoryData[this.inventorySelectionIndex];
+    if (!item) {
+      return;
+    }
+    this.emitGameEvent("ui-assign-quick-slot", { slotIndex, itemId: item.id });
+  }
+
+  modifyOption(direction) {
+    const config = this.optionsConfig[this.optionsSelectionIndex];
+    if (!config || (config.type !== "range" && config.type !== "choice")) {
+      return;
+    }
+    const state = this.optionsState || {};
+    const hasCurrent = Object.prototype.hasOwnProperty.call(state, config.key);
+    const current = hasCurrent ? state[config.key] : undefined;
+    let nextValue = current;
+
+    if (config.type === "range") {
+      const step = typeof config.step === "number" ? config.step : 0.1;
+      const baseValue = typeof current === "number" ? current : config.min;
+      nextValue = Phaser.Math.Clamp(baseValue + step * direction, config.min, config.max);
+    } else if (config.type === "choice") {
+      const list = Array.isArray(config.values) ? config.values : [];
+      if (list.length === 0) {
+        return;
+      }
+      const fallback = list[0];
+      const currentIndex = Math.max(0, list.indexOf(hasCurrent ? current : fallback));
+      const nextIndex = Phaser.Math.Wrap(currentIndex + direction, 0, list.length);
+      nextValue = list[nextIndex];
+    }
+
+    this.optionsState = Object.assign({}, state, { [config.key]: nextValue });
+    this.refreshOptionsList();
+    this.emitGameEvent("ui-options-change", { [config.key]: nextValue });
+  }
+
+  beginBindingCapture(config) {
+    if (!config || !config.action) {
+      return;
+    }
+    this.bindingListenAction = config.action;
+    this.bindingListenLabel = config.label ? config.label : config.action;
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(
+        `${this.bindingListenLabel} - \uc0c8 \ud0a4 \uc785\ub825 (ESC \ucde8\uc18c)`
+      );
+    }
+    this.refreshOptionsList();
+  }
+
+  cancelBindingCapture() {
+    if (!this.bindingListenAction) {
+      return;
+    }
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(this.optionsHintBase);
+    }
+    this.refreshOptionsList();
+  }
+
+  completeBindingCapture(keyCode) {
+    const action = this.bindingListenAction;
+    if (!action) {
+      return;
+    }
+    this.bindingListenAction = null;
+    this.bindingListenLabel = "";
+    if (this.optionsHintText && this.optionsHintBase) {
+      this.optionsHintText.setText(this.optionsHintBase);
+    }
+    this.emitGameEvent("ui-rebind-action", { action, keyCode });
+    this.refreshOptionsList();
+  }
+
+  triggerOptionAction(config) {
+    if (!config) {
+      return;
+    }
+    if (config.action === "reset-bindings") {
+      this.cancelBindingCapture();
+      this.emitGameEvent("ui-reset-bindings");
+    }
+  }
+
+  handleGlobalKeydown(event) {
+    if (!this.bindingListenAction) {
+      return;
+    }
+    if (event.repeat) {
+      return;
+    }
+    if (event.key === "Escape" || event.key === "Esc") {
+      this.cancelBindingCapture();
+      return;
+    }
+    const keyCode = typeof event.keyCode === "number" ? event.keyCode : event.which;
+    if (typeof keyCode !== "number" || !Number.isFinite(keyCode)) {
+      return;
+    }
+    if (typeof event.preventDefault === "function") {
+      event.preventDefault();
+    }
+    if (typeof event.stopPropagation === "function") {
+      event.stopPropagation();
+    }
+    this.completeBindingCapture(keyCode);
+  }
+
+  refreshInventoryList() {
+    if (!this.inventoryData.length) {
+      this.inventoryListText.setText(["(\uc544\uc774\ud15c \uc5c6\uc74c)"]);
+      this.inventoryDetailText.setText("\uc804\ub9ac\ud488\uc744 \ud68d\ub4dd\ud574 \uc778\ubca4\ud1a0\ub9ac\ub97c \ucc44\uc6b0\uc138\uc694.");
+      return;
+    }
+
+    this.inventorySelectionIndex = Phaser.Math.Clamp(this.inventorySelectionIndex, 0, this.inventoryData.length - 1);
+
+    const quickSlotMap = new Map();
+    this.quickSlotData.forEach((slot) => {
+      if (slot && slot.itemId) {
+        quickSlotMap.set(slot.itemId, slot.index + 1);
+      }
+    });
+
+    const lines = this.inventoryData.map((item, index) => {
+      const selector = index === this.inventorySelectionIndex ? "\u25b6" : " ";
+      const slotTag = quickSlotMap.has(item.id) ? ` [${quickSlotMap.get(item.id)}]` : "";
+      return `${selector} ${item.name}${slotTag}  x${item.quantity}`;
+    });
+
+    this.inventoryListText.setText(lines);
+    const selected = this.inventoryData[this.inventorySelectionIndex];
+    const detailText = selected && selected.description ? selected.description : "\uc0c1\uc138 \uc124\uba85\uc774 \uc5c6\uc2b5\ub2c8\ub2e4.";
+    this.inventoryDetailText.setText(detailText);
+  }
+
+  ensureOptionsSelectionVisible() {
+    const total = Array.isArray(this.optionsConfig) ? this.optionsConfig.length : 0;
+    const visibleCount = OPTIONS_VISIBLE_COUNT;
+    if (total <= visibleCount) {
+      this.optionsScrollOffset = 0;
+      return;
+    }
+    const maxOffset = Math.max(0, total - visibleCount);
+    if (this.optionsSelectionIndex < this.optionsScrollOffset) {
+      this.optionsScrollOffset = this.optionsSelectionIndex;
+    } else if (this.optionsSelectionIndex > this.optionsScrollOffset + visibleCount - 1) {
+      this.optionsScrollOffset = this.optionsSelectionIndex - visibleCount + 1;
+    }
+    this.optionsScrollOffset = Phaser.Math.Clamp(this.optionsScrollOffset, 0, maxOffset);
+  }
+
+  refreshOptionsList() {
+    if (!this.optionsListText) {
+      return;
+    }
+
+    this.ensureOptionsSelectionVisible();
+
+    const lines = this.optionsConfig.map((config, index) => {
+      const selector = index === this.optionsSelectionIndex ? "\u25b6" : " ";
+      if (config.type === "action") {
+        const suffix = config.action === "reset-bindings" ? " (Enter)" : "";
+        return `${selector} ${config.label}${suffix}`;
+      }
+      const value = this.formatOptionValue(config);
+      return `${selector} ${config.label}: ${value}`;
+    });
+
+    const start = this.optionsScrollOffset;
+    const end = Math.min(lines.length, start + OPTIONS_VISIBLE_COUNT);
+    const visibleLines = lines.slice(start, end);
+
+    if (start > 0) {
+      visibleLines.unshift("⋮");
+    }
+    if (end < lines.length) {
+      visibleLines.push("⋮");
+    }
+
+    this.optionsListText.setText(visibleLines);
+  }
+
+  formatOptionValue(config) {
+    if (config.type === "binding") {
+      if (this.bindingListenAction === config.action) {
+        return "[\uc785\ub825 \ub300\uae30]";
+      }
+      return this.formatBindingValue(config.action);
+    }
+    if (config.type === "action") {
+      return "";
+    }
+    const state = this.optionsState || {};
+    const hasValue = Object.prototype.hasOwnProperty.call(state, config.key);
+    const value = hasValue ? state[config.key] : undefined;
+    if (config.type === "range") {
+      if (config.key === "resolutionScale") {
+        const scale = typeof value === "number" ? value : 1;
+        return `${Math.round(scale * 100)}%`;
+      }
+      const numeric = typeof value === "number" ? value : 0;
+      return `${Math.round(numeric * 100)}%`;
+    }
+    if (config.type === "choice") {
+      const list = Array.isArray(config.values) ? config.values : [];
+      if (hasValue) {
+        return value;
+      }
+      return list.length > 0 ? list[0] : "";
+    }
+    if (hasValue && value != null) {
+      return value;
+    }
+    const defaults = Array.isArray(config.values) ? config.values : [];
+    return defaults.length > 0 ? defaults[0] : "";
+  }
+
+  formatBindingValue(action) {
+    if (!action) {
+      return "--";
+    }
+    const entry = this.bindingLookup.get(action);
+    if (!entry) {
+      return "--";
+    }
+    if (Array.isArray(entry.labels) && entry.labels.length) {
+      return entry.labels.join(" / ");
+    }
+    if (Array.isArray(entry.codes) && entry.codes.length) {
+      return entry.codes.map((code) => String(code)).join(" / ");
+    }
+    return "--";
+  }
+
+  createOptionsConfig() {
+    return [
+      { key: "masterVolume", label: "Master Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "sfxVolume", label: "SFX Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "bgmVolume", label: "BGM Volume", type: "range", min: 0, max: 1, step: 0.1 },
+      { key: "resolutionScale", label: "Resolution Scale", type: "range", min: 0.7, max: 1.1, step: 0.05 },
+      { key: "graphicsQuality", label: "Graphics Quality", type: "choice", values: ["High", "Performance"] },
+      { key: "bind.moveLeft", label: "Move Left", type: "binding", action: INPUT_KEYS.LEFT },
+      { key: "bind.moveRight", label: "Move Right", type: "binding", action: INPUT_KEYS.RIGHT },
+      { key: "bind.moveUp", label: "Move Up", type: "binding", action: INPUT_KEYS.UP },
+      { key: "bind.moveDown", label: "Move Down", type: "binding", action: INPUT_KEYS.DOWN },
+      { key: "bind.jump", label: "Jump", type: "binding", action: INPUT_KEYS.JUMP },
+      { key: "bind.dash", label: "Dash", type: "binding", action: INPUT_KEYS.DASH },
+      { key: "bind.attackPrimary", label: "Primary Attack", type: "binding", action: INPUT_KEYS.ATTACK_PRIMARY },
+      { key: "bind.attackSecondary", label: "Secondary Attack", type: "binding", action: INPUT_KEYS.ATTACK_SECONDARY },
+      { key: "bind.interact", label: "Interact", type: "binding", action: INPUT_KEYS.INTERACT },
+      { key: "bind.inventory", label: "Inventory Menu", type: "binding", action: INPUT_KEYS.INVENTORY },
+      { key: "bind.options", label: "Options Menu", type: "binding", action: INPUT_KEYS.OPTIONS },
+      { key: "resetBindings", label: "Reset Key Bindings", type: "action", action: "reset-bindings" }
+    ];
+  }
+
+  getLabelStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "16px",
+      color: "#9ca6cf"
+    };
+  }
+
+  getValueStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "18px",
+      color: "#f5f6ff"
+    };
+  }
+
+  getHintStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "14px",
+      color: "#9ca6cf"
+    };
+  }
+
+  getTitleStyle() {
+    return {
+      fontFamily: "Rubik, 'Segoe UI', sans-serif",
+      fontSize: "24px",
+      color: "#f7f8ff"
+    };
+  }
+
+  shutdown() {
+    if (this.gameScene && this.gameScene.events) {
+      this.gameScene.events.off("ui-state", this.handleStateUpdate, this);
+      this.gameScene.events.off("ui-panel", this.handlePanelToggle, this);
+      this.gameScene.events.off("ui-menu-state", this.handleMenuState, this);
+    }
+    this.cancelBindingCapture();
+    if (this.input && this.input.keyboard) {
+      this.input.keyboard.off("keydown", this.handleGlobalKeydown, this);
+      this.input.keyboard.off("keydown-ESC", this.handleEscKey, this);
+    }
+    if (this.bugToggleKey) {
+      this.bugToggleKey.destroy();
+      this.bugToggleKey = null;
+    }
+    this.gameScene = null;
+  }
+}

--- a/phaser-vertical-slice/src/systems/AssetLoader.js
+++ b/phaser-vertical-slice/src/systems/AssetLoader.js
@@ -1,6 +1,19 @@
-﻿import Phaser from "../phaser.js";
+import Phaser from "../phaser.js";
 
-const ASSET_BASE_PATH = "public";
+function resolveAssetBasePath() {
+  if (typeof window !== "undefined" && window.location) {
+    try {
+      const resolved = new URL("./public/", window.location.href);
+      return resolved.pathname.replace(/\/+$/, "");
+    } catch (err) {
+      console.warn("[Skywood] Failed to resolve public asset path, falling back.", err);
+    }
+  }
+
+  return "public";
+}
+
+const ASSET_BASE_PATH = resolveAssetBasePath();
 
 export const ASSET_KEYS = Object.freeze({
   ATLAS: {

--- a/phaser-vertical-slice/src/systems/AudioManager.js
+++ b/phaser-vertical-slice/src/systems/AudioManager.js
@@ -1,20 +1,311 @@
-﻿export default class AudioManager {
+import Phaser from "../phaser.js";
+
+export default class AudioManager {
   constructor(scene) {
     this.scene = scene;
+    this.masterVolume = 0.8;
+    this.sfxVolume = 0.9;
+    this.bgmVolume = 0.7;
+    this.currentBgm = null;
+    this.currentBgmKey = null;
+    this.bgmTween = null;
+    this.duckMultiplier = 1;
+    this.focusMuted = false;
+    this.pendingUnlockCallback = null;
+    // Background music asset is temporarily unavailable; leave playback disabled
+    // until a text-based or procedural replacement is supplied.
+    this.bgmPlaybackEnabled = false;
+
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleScenePause = this.handleScenePause.bind(this);
+    this.handleSceneResume = this.handleSceneResume.bind(this);
+
+    this.scene.game.events.on(Phaser.Core.Events.BLUR, this.handleBlur);
+    this.scene.game.events.on(Phaser.Core.Events.FOCUS, this.handleFocus);
+    this.scene.events.on(Phaser.Scenes.Events.PAUSE, this.handleScenePause, this);
+    this.scene.events.on(Phaser.Scenes.Events.RESUME, this.handleSceneResume, this);
+    this.scene.events.on(Phaser.Scenes.Events.SLEEP, this.handleScenePause, this);
+    this.scene.events.on(Phaser.Scenes.Events.WAKE, this.handleSceneResume, this);
+    this.scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
   }
 
   play(key, spriteKey) {
     if (!this.scene.sound || this.scene.sound.locked) {
       return;
     }
+    const volume = Phaser.Math.Clamp(this.masterVolume * this.sfxVolume, 0, 1);
     try {
       if (spriteKey) {
-        this.scene.sound.playAudioSprite(key, spriteKey, { volume: 0.6 });
+        this.scene.sound.playAudioSprite(key, spriteKey, { volume });
       } else {
-        this.scene.sound.play(key, { volume: 0.6 });
+        this.scene.sound.play(key, { volume });
       }
     } catch (error) {
       // ignore play failure
+    }
+  }
+
+  applyMixSettings(patch = {}) {
+    if (patch.masterVolume !== undefined) {
+      this.masterVolume = Phaser.Math.Clamp(patch.masterVolume, 0, 1);
+    }
+    if (patch.sfxVolume !== undefined) {
+      this.sfxVolume = Phaser.Math.Clamp(patch.sfxVolume, 0, 1);
+    }
+    if (patch.bgmVolume !== undefined) {
+      this.bgmVolume = Phaser.Math.Clamp(patch.bgmVolume, 0, 1);
+    }
+    this.updateBgmVolume(240);
+  }
+
+  playBgm(key, config = {}) {
+    if (!this.scene.sound || !this.bgmPlaybackEnabled) {
+      return;
+    }
+
+    const cache = this.scene.cache?.audio;
+    if (!cache || !cache.exists(key)) {
+      console.warn(`[Skywood] BGM '${key}' is not loaded.`);
+      return;
+    }
+
+    const startPlayback = () => {
+      const loop = config.loop !== false;
+      const crossFade = Math.max(0, config.crossFade ?? 300);
+      const fadeIn = Math.max(0, config.fadeIn ?? 600);
+      const startAt = Math.max(0, config.seek ?? 0);
+
+      if (this.currentBgmKey === key && this.currentBgm) {
+        if (!this.currentBgm.isPlaying) {
+          this.currentBgm.play({ loop, seek: startAt, volume: 0 });
+        }
+        this.updateBgmVolume(fadeIn);
+        return;
+      }
+
+      const previous = this.currentBgm;
+      if (previous) {
+        this.fadeOutSound(previous, crossFade);
+      }
+
+      let sound = null;
+      try {
+        sound = this.scene.sound.add(key, { loop, volume: 0 });
+      } catch (error) {
+        console.warn(`[Skywood] Failed to start BGM '${key}':`, error);
+        return;
+      }
+
+      if (!sound) {
+        return;
+      }
+
+      this.currentBgm = sound;
+      this.currentBgmKey = key;
+      this.duckMultiplier = 1;
+
+      sound.once(Phaser.Sound.Events.DESTROY, () => {
+        if (this.currentBgm === sound) {
+          this.currentBgm = null;
+          this.currentBgmKey = null;
+        }
+      });
+
+      try {
+        sound.play({ loop, seek: startAt, volume: 0 });
+      } catch (error) {
+        console.warn(`[Skywood] Unable to play BGM '${key}':`, error);
+        sound.destroy();
+        if (this.currentBgm === sound) {
+          this.currentBgm = null;
+          this.currentBgmKey = null;
+        }
+        return;
+      }
+
+      this.updateBgmVolume(fadeIn);
+    };
+
+    if (this.scene.sound.locked) {
+      this.queueUnlock(startPlayback);
+    } else {
+      startPlayback();
+    }
+  }
+
+  stopBgm(options = {}) {
+    const sound = this.currentBgm;
+    if (!sound) {
+      return;
+    }
+
+    const fadeOut = Math.max(0, options.fadeOut ?? 260);
+    const immediate = options.immediate === true;
+    this.clearBgmTween();
+
+    const finalize = () => {
+      if (sound.isPlaying || sound.isPaused) {
+        sound.stop();
+      }
+      sound.destroy();
+      if (this.currentBgm === sound) {
+        this.currentBgm = null;
+        this.currentBgmKey = null;
+      }
+    };
+
+    if (immediate || fadeOut === 0) {
+      finalize();
+      return;
+    }
+
+    this.scene.tweens.add({
+      targets: sound,
+      volume: 0,
+      ease: "Sine.easeIn",
+      duration: fadeOut,
+      onComplete: finalize
+    });
+  }
+
+  pauseBgm() {
+    if (this.currentBgm && this.currentBgm.isPlaying) {
+      this.currentBgm.pause();
+    }
+  }
+
+  resumeBgm() {
+    if (this.currentBgm && this.currentBgm.isPaused) {
+      this.currentBgm.resume();
+      this.updateBgmVolume(200);
+    }
+  }
+
+  setDuck(enabled, ratio = 0.5, duration = 200) {
+    const clamped = Phaser.Math.Clamp(ratio, 0, 1);
+    this.duckMultiplier = enabled ? clamped : 1;
+    this.updateBgmVolume(duration);
+  }
+
+  updateBgmVolume(duration = 0) {
+    if (!this.currentBgm) {
+      return;
+    }
+    const target = this.focusMuted
+      ? 0
+      : Phaser.Math.Clamp(this.masterVolume * this.bgmVolume * this.duckMultiplier, 0, 1);
+    if (duration > 0) {
+      this.fadeBgm(target, duration);
+    } else {
+      this.clearBgmTween();
+      this.currentBgm.setVolume(target);
+    }
+  }
+
+  fadeBgm(targetVolume, duration = 240) {
+    if (!this.currentBgm) {
+      return;
+    }
+    this.clearBgmTween();
+    this.bgmTween = this.scene.tweens.add({
+      targets: this.currentBgm,
+      volume: Phaser.Math.Clamp(targetVolume, 0, 1),
+      ease: "Sine.easeInOut",
+      duration: Math.max(0, duration),
+      onComplete: () => {
+        this.bgmTween = null;
+      }
+    });
+  }
+
+  fadeOutSound(sound, duration) {
+    if (!sound) {
+      return;
+    }
+    const tweenDuration = Math.max(0, duration);
+    if (tweenDuration === 0) {
+      if (sound.isPlaying || sound.isPaused) {
+        sound.stop();
+      }
+      sound.destroy();
+      return;
+    }
+    this.scene.tweens.add({
+      targets: sound,
+      volume: 0,
+      ease: "Sine.easeIn",
+      duration: tweenDuration,
+      onComplete: () => {
+        if (sound.isPlaying || sound.isPaused) {
+          sound.stop();
+        }
+        sound.destroy();
+      }
+    });
+  }
+
+  queueUnlock(callback) {
+    if (!this.scene.sound) {
+      return;
+    }
+    if (this.pendingUnlockCallback) {
+      this.scene.sound.off(Phaser.Sound.Events.UNLOCKED, this.pendingUnlockCallback);
+      this.pendingUnlockCallback = null;
+    }
+    const wrapped = () => {
+      this.scene.sound.off(Phaser.Sound.Events.UNLOCKED, wrapped);
+      this.pendingUnlockCallback = null;
+      callback();
+    };
+    this.pendingUnlockCallback = wrapped;
+    this.scene.sound.once(Phaser.Sound.Events.UNLOCKED, wrapped);
+  }
+
+  handleBlur() {
+    this.focusMuted = true;
+    this.updateBgmVolume(180);
+  }
+
+  handleFocus() {
+    this.focusMuted = false;
+    this.updateBgmVolume(260);
+  }
+
+  handleScenePause() {
+    this.pauseBgm();
+  }
+
+  handleSceneResume() {
+    this.resumeBgm();
+  }
+
+  clearBgmTween() {
+    if (this.bgmTween) {
+      this.bgmTween.stop();
+      this.bgmTween = null;
+    }
+  }
+
+  destroy() {
+    this.scene.game.events.off(Phaser.Core.Events.BLUR, this.handleBlur);
+    this.scene.game.events.off(Phaser.Core.Events.FOCUS, this.handleFocus);
+    this.scene.events.off(Phaser.Scenes.Events.PAUSE, this.handleScenePause, this);
+    this.scene.events.off(Phaser.Scenes.Events.RESUME, this.handleSceneResume, this);
+    this.scene.events.off(Phaser.Scenes.Events.SLEEP, this.handleScenePause, this);
+    this.scene.events.off(Phaser.Scenes.Events.WAKE, this.handleSceneResume, this);
+    if (this.pendingUnlockCallback) {
+      this.scene.sound?.off(Phaser.Sound.Events.UNLOCKED, this.pendingUnlockCallback);
+      this.pendingUnlockCallback = null;
+    }
+    this.clearBgmTween();
+    if (this.currentBgm) {
+      if (this.currentBgm.isPlaying || this.currentBgm.isPaused) {
+        this.currentBgm.stop();
+      }
+      this.currentBgm.destroy();
+      this.currentBgm = null;
+      this.currentBgmKey = null;
     }
   }
 }

--- a/phaser-vertical-slice/src/systems/PerfMeter.js
+++ b/phaser-vertical-slice/src/systems/PerfMeter.js
@@ -29,9 +29,37 @@ export default class PerfMeter {
 
     const fps = this.scene.game.loop.actualFps;
     const frameMs = this.scene.game.loop.delta;
-    const objectCount = this.scene.children.list.length;
+    const snapshot =
+      typeof this.scene.getPerfSnapshot === "function" ? this.scene.getPerfSnapshot() : null;
 
-    this.text.setText(`FPS ${fps.toFixed(1)}\nMS ${frameMs.toFixed(2)}\nOBJS ${objectCount}`);
+    const lines = [`FPS ${fps.toFixed(1)}`, `MS ${frameMs.toFixed(2)}`];
+
+    if (snapshot) {
+      const objects = snapshot.objects ?? this.scene.children.list.length;
+      const mobsVisible = snapshot.mobsVisible ?? snapshot.mobs ?? 0;
+      const mobsActive = snapshot.mobsActive ?? mobsVisible;
+      const projectiles = snapshot.projectiles ?? 0;
+      lines.push(`OBJ ${objects}`);
+      lines.push(`MOB ${mobsVisible}/${mobsActive}`);
+      lines.push(`PRJ ${projectiles}`);
+      const projectilePool = snapshot.pools?.projectile;
+      if (projectilePool) {
+        lines.push(
+          `PP ${Math.max(0, projectilePool.live ?? 0)}/${Math.max(0, projectilePool.free ?? 0)}`
+        );
+      }
+      const textPool = snapshot.pools?.damageText;
+      if (textPool) {
+        lines.push(
+          `TP ${Math.max(0, textPool.live ?? 0)}/${Math.max(0, textPool.free ?? 0)}`
+        );
+      }
+    } else {
+      const objectCount = this.scene.children.list.length;
+      lines.push(`OBJ ${objectCount}`);
+    }
+
+    this.text.setText(lines.join("\n"));
 
     this.elapsed = 0;
   }

--- a/phaser-vertical-slice/src/systems/Pool.js
+++ b/phaser-vertical-slice/src/systems/Pool.js
@@ -22,4 +22,12 @@
   forEachLive(fn) {
     this.live.forEach(fn);
   }
+
+  getLiveCount() {
+    return this.live.size;
+  }
+
+  getFreeCount() {
+    return this.free.length;
+  }
 }

--- a/phaser-vertical-slice/src/systems/SaveManager.js
+++ b/phaser-vertical-slice/src/systems/SaveManager.js
@@ -1,0 +1,102 @@
+const DEFAULT_STORAGE_KEY = "skywood.save.slot0";
+
+function hasWindowStorage() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return typeof window.localStorage !== "undefined" && window.localStorage !== null;
+  } catch (error) {
+    console.warn("[Skywood] localStorage unavailable:", error);
+    return false;
+  }
+}
+
+function probeStorage(storage, key) {
+  const probeKey = `${key}.__probe`;
+  try {
+    storage.setItem(probeKey, "1");
+    storage.removeItem(probeKey);
+    return true;
+  } catch (error) {
+    console.warn("[Skywood] Failed to probe storage:", error);
+    return false;
+  }
+}
+
+export default class SaveManager {
+  constructor(storageKey = DEFAULT_STORAGE_KEY) {
+    this.storageKey = storageKey;
+    this.available = false;
+    this.storage = null;
+
+    if (hasWindowStorage()) {
+      try {
+        const candidate = window.localStorage;
+        if (candidate && probeStorage(candidate, storageKey)) {
+          this.storage = candidate;
+          this.available = true;
+        }
+      } catch (error) {
+        console.warn("[Skywood] Save system disabled:", error);
+        this.available = false;
+        this.storage = null;
+      }
+    }
+  }
+
+  isAvailable() {
+    return this.available && Boolean(this.storage);
+  }
+
+  load() {
+    if (!this.isAvailable()) {
+      return null;
+    }
+    try {
+      const raw = this.storage.getItem(this.storageKey);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    } catch (error) {
+      console.warn("[Skywood] Failed to load save data:", error);
+    }
+    return null;
+  }
+
+  save(data) {
+    if (!this.isAvailable()) {
+      return { ok: false, reason: "unavailable" };
+    }
+    try {
+      const now = Date.now();
+      const payload = { version: 1, timestamp: now, ...data };
+      this.storage.setItem(this.storageKey, JSON.stringify(payload));
+      return { ok: true, timestamp: now };
+    } catch (error) {
+      console.warn("[Skywood] Failed to save progress:", error);
+      this.available = probeStorage(this.storage, this.storageKey);
+      if (!this.available) {
+        return { ok: false, reason: "unavailable" };
+      }
+      return { ok: false, reason: "error" };
+    }
+  }
+
+  clear() {
+    if (!this.isAvailable()) {
+      return false;
+    }
+    try {
+      this.storage.removeItem(this.storageKey);
+      return true;
+    } catch (error) {
+      console.warn("[Skywood] Failed to clear save data:", error);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend the player's post-hit invulnerability window to 2000ms via a config constant to match the requested 2-second i-frames
- track dash direction and keep gravity enabled during the dash so the player no longer clips through terrain while keeping the burst movement

## Testing
- node --check phaser-vertical-slice/src/entities/Player.js

------
https://chatgpt.com/codex/tasks/task_e_68cad606aac0832b94fbed009ad0b8bd