### PR TITLE
Reset resetQueued flag when GameScene recreates

### DIFF
--- a/phaser-vertical-slice/src/scenes/GameScene.js
+++ b/phaser-vertical-slice/src/scenes/GameScene.js
@@ -67,6 +67,8 @@ export default class GameScene extends Phaser.Scene {
   }
 
   create() {
+    this.resetQueued = false;
+
     this.cameras.main.setBackgroundColor("#2a2f3a");
 
     this.saveManager = new SaveManager();


### PR DESCRIPTION
## Summary
- ensure GameScene clears the resetQueued flag at the start of create so repeated reset requests are processed after a restart

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc55af3a90832bae7c92561baeab5b